### PR TITLE
Fixed selection bug after pasting

### DIFF
--- a/src/Myra/Graphics2D/UI/TextBox.cs
+++ b/src/Myra/Graphics2D/UI/TextBox.cs
@@ -458,6 +458,7 @@ namespace Myra.Graphics2D.UI
 			{
 				UndoStack.MakeInsert(CursorPosition, text.Length());
 				CursorPosition += text.Length;
+				ResetSelection();
 				return true;
 			}
 


### PR DESCRIPTION
Steps to reproduce:
- Paste some text into the textbox
- Press shift+left

Fixed by calling ResetSelection() after pasting
