### PR TITLE
[Proposal] Draggable widget

### DIFF
--- a/src/Myra/Graphics2D/UI/Enums.cs
+++ b/src/Myra/Graphics2D/UI/Enums.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Myra.Graphics2D.UI
 {
 	public enum HorizontalAlignment
@@ -40,5 +42,13 @@ namespace Myra.Graphics2D.UI
 		/// Multiple items can be selected
 		/// </summary>
 		Multiple
+	}
+
+	[Flags]
+	public enum DragDirection
+	{
+		All = 0,
+		Vertical = 1,
+		Horizontal = 2
 	}
 }

--- a/src/Myra/Graphics2D/UI/Enums.cs
+++ b/src/Myra/Graphics2D/UI/Enums.cs
@@ -47,8 +47,8 @@ namespace Myra.Graphics2D.UI
 	[Flags]
 	public enum DragDirection
 	{
-		All = 0,
 		Vertical = 1,
-		Horizontal = 2
+		Horizontal = 2,
+		Both = Vertical | Horizontal
 	}
 }

--- a/src/Myra/Graphics2D/UI/Widget.cs
+++ b/src/Myra/Graphics2D/UI/Widget.cs
@@ -527,7 +527,8 @@ namespace Myra.Graphics2D.UI
 		public bool IsDraggable { get; set; }
 
 		[Category("Behavior")]
-		public DragDirection DragDirection { get; set; }
+		[DefaultValue(DragDirection.Both)]
+		public DragDirection DragDirection { get; set; } = DragDirection.Both;
 
 		[Category("Behavior")]
 		public Widget DragHandle { get; set; }


### PR DESCRIPTION
Any widget now is draggable

Widget Window has been updated to use the base implementation.
It is allowed to specify the DragHandle that will launch the drag.
Blocking drag per direction is allowed.

Example usage:
```c#
var labelDragHandle = new Label() { Text = "Drag handle" };
var draggableWidget = new VerticalStackPanel
{
    Border = new SolidBrush(Color.Red),
    BorderThickness = new Thickness(1),
    Left = 100,
    Top = 100,
    Width = 250,
    Height = 250,

    IsDraggable = true,
    DragHandle = labelDragHandle,
    DragDirection = DragDirection.Horizontal,

    Widgets = {
        labelDragHandle,
        new Label() { Text = "This is body content" }
    }
};
```