### PR TITLE
Add generic method for adding child to widgets

### DIFF
--- a/src/Myra/Graphics2D/UI/IMultipleItemsContainer.cs
+++ b/src/Myra/Graphics2D/UI/IMultipleItemsContainer.cs
@@ -5,5 +5,6 @@ namespace Myra.Graphics2D.UI
 	public interface IMultipleItemsContainer
 	{
 		ObservableCollection<Widget> Widgets { get; }
+		T AddChild<T>(T widget) where T : Widget;
 	}
 }

--- a/src/Myra/Graphics2D/UI/MultipleItemsContainerBase.cs
+++ b/src/Myra/Graphics2D/UI/MultipleItemsContainerBase.cs
@@ -81,6 +81,12 @@ namespace Myra.Graphics2D.UI
 			InvalidateChildren();
 		}
 
+		public T AddChild<T>(T widget) where T : Widget
+		{
+			Widgets.Add(widget);
+			return widget;
+		}
+
 		public override void RemoveChild(Widget widget)
 		{
 			_widgets.Remove(widget);

--- a/src/Myra/Graphics2D/UI/StackPanel.cs
+++ b/src/Myra/Graphics2D/UI/StackPanel.cs
@@ -136,6 +136,12 @@ namespace Myra.Graphics2D.UI
 			_dirty = false;
 		}
 
+		public T AddChild<T>(T widget) where T : Widget
+		{
+			Widgets.Add(widget);
+			return widget;
+		}
+
 		private void Widgets_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
 		{
 			_dirty = true;


### PR DESCRIPTION
Hey,

I added a generic method for when you're adding a widget to a multiple item container.

### Reasoning

I like to be able to assign anything that I add to the widgets directly, without having to create the variable first. So rather than:

```
var myWidget = new Button();
parentWidget.Widgets.Add(myWidget);
```

We can use:
```
var myWidget = parentWidget.AddChild(new Button());
```

### Risk
Minimal risk as I didn't remove the public accessor for the Widgets. I just added an extra method that can be used as an alternative to adding directly to the list.