### PR TITLE
Add systems and keyboard tabbing

### DIFF
--- a/src/Myra/Graphics2D/UI/ButtonBase.cs
+++ b/src/Myra/Graphics2D/UI/ButtonBase.cs
@@ -199,7 +199,7 @@ namespace Myra.Graphics2D.UI
 
 		public override IBrush GetCurrentBackground()
 		{
-			var result = Background;
+			var result = base.GetCurrentBackground();
 
 			if (Enabled)
 			{

--- a/src/Myra/Graphics2D/UI/ComboBox.cs
+++ b/src/Myra/Graphics2D/UI/ComboBox.cs
@@ -65,7 +65,7 @@ namespace Myra.Graphics2D.UI
 			}
 		}
 
-		protected internal override bool AcceptsKeyboardFocus => true;
+		public override bool AcceptsKeyboardFocus => true;
 
 		public override ObservableCollection<ListItem> Items => _listBox.Items;
 

--- a/src/Myra/Graphics2D/UI/Container.cs
+++ b/src/Myra/Graphics2D/UI/Container.cs
@@ -52,6 +52,28 @@ namespace Myra.Graphics2D.UI
 			}
 		}
 
+		public override bool Visible
+		{
+			get
+			{
+				return base.Visible;
+			}
+			set
+			{
+				if (base.Visible == value)
+				{
+					return;
+				}
+
+				base.Visible = value;
+
+				foreach (var item in ChildrenCopy)
+				{
+					item.Visible = value;
+				}
+			}
+		}
+
 		public override Desktop Desktop 
 		{
 			get

--- a/src/Myra/Graphics2D/UI/ImageTextButton.cs
+++ b/src/Myra/Graphics2D/UI/ImageTextButton.cs
@@ -32,6 +32,11 @@ namespace Myra.Graphics2D.UI
 			}
 		}
 
+		protected internal override bool AcceptsKeyboardFocus
+		{
+			get => true;
+		}
+
 		[Category("Appearance")]
 		[StylePropertyPath("/LabelStyle/TextColor")]
 		public virtual Color TextColor

--- a/src/Myra/Graphics2D/UI/ImageTextButton.cs
+++ b/src/Myra/Graphics2D/UI/ImageTextButton.cs
@@ -32,11 +32,6 @@ namespace Myra.Graphics2D.UI
 			}
 		}
 
-		protected internal override bool AcceptsKeyboardFocus
-		{
-			get => true;
-		}
-
 		[Category("Appearance")]
 		[StylePropertyPath("/LabelStyle/TextColor")]
 		public virtual Color TextColor

--- a/src/Myra/Graphics2D/UI/ListBox.cs
+++ b/src/Myra/Graphics2D/UI/ListBox.cs
@@ -43,7 +43,7 @@ namespace Myra.Graphics2D.UI
 
 		protected internal override bool AcceptsMouseWheelFocus => InternalChild.AcceptsMouseWheelFocus;
 
-		internal protected override bool AcceptsKeyboardFocus
+		public override bool AcceptsKeyboardFocus
 		{
 			get { return true; }
 		}

--- a/src/Myra/Graphics2D/UI/Menu.cs
+++ b/src/Myra/Graphics2D/UI/Menu.cs
@@ -325,7 +325,7 @@ namespace Myra.Graphics2D.UI
 			}
 		}
 
-		protected internal override bool AcceptsKeyboardFocus => true;
+		public override bool AcceptsKeyboardFocus => true;
 
 		protected Menu(string styleName)
 		{

--- a/src/Myra/Graphics2D/UI/SpinButton.cs
+++ b/src/Myra/Graphics2D/UI/SpinButton.cs
@@ -214,7 +214,7 @@ namespace Myra.Graphics2D.UI
 		[DefaultValue(1f)]
 		public float Mul_Increment { get; set; } = 1f;
 
-		internal protected override bool AcceptsKeyboardFocus
+		public override bool AcceptsKeyboardFocus
 		{
 			get { return true; }
 		}

--- a/src/Myra/Graphics2D/UI/TextBox.cs
+++ b/src/Myra/Graphics2D/UI/TextBox.cs
@@ -368,6 +368,18 @@ namespace Myra.Graphics2D.UI
 			SetStyle(styleName);
 
 			BlinkIntervalInMs = 450;
+
+			KeyboardFocusChanged += (e, a) =>
+			{
+				if (IsKeyboardFocused)
+				{
+					OnGotKeyboardFocus();
+				}
+				else
+				{
+					OnLostKeyboardFocus();
+				}
+			};
 		}
 
 		private void DeleteChars(int pos, int l)

--- a/src/Myra/Graphics2D/UI/TextBox.cs
+++ b/src/Myra/Graphics2D/UI/TextBox.cs
@@ -244,7 +244,7 @@ namespace Myra.Graphics2D.UI
 
 		internal bool InternalAcceptsKeyboardFocus = true;
 
-		internal protected override bool AcceptsKeyboardFocus
+		public override bool AcceptsKeyboardFocus
 		{
 			get { return InternalAcceptsKeyboardFocus; }
 		}

--- a/src/Myra/Graphics2D/UI/Tree.cs
+++ b/src/Myra/Graphics2D/UI/Tree.cs
@@ -58,7 +58,7 @@ namespace Myra.Graphics2D.UI
 			}
 		}
 
-		protected internal override bool AcceptsKeyboardFocus => true;
+		public override bool AcceptsKeyboardFocus => true;
 
 		[DefaultValue(true)]
 		public bool HasRoot

--- a/src/Myra/Graphics2D/UI/Widget.cs
+++ b/src/Myra/Graphics2D/UI/Widget.cs
@@ -815,11 +815,19 @@ namespace Myra.Graphics2D.UI
 			}
 		}
 
-		[Browsable(false)]
-		[XmlIgnore]
-		internal protected virtual bool AcceptsKeyboardFocus
+		private bool _acceptsKeyboardFocus;
+		
+		[Category("Behavior")]
+		public virtual bool AcceptsKeyboardFocus
 		{
-			get { return false; }
+			get
+			{
+				return _acceptsKeyboardFocus;
+			}
+			set
+			{
+				_acceptsKeyboardFocus = value;
+			}
 		}
 
 		[Browsable(false)]

--- a/src/Myra/Graphics2D/UI/Widget.cs
+++ b/src/Myra/Graphics2D/UI/Widget.cs
@@ -506,7 +506,7 @@ namespace Myra.Graphics2D.UI
 
 		[Category("Behavior")]
 		[DefaultValue(true)]
-		public bool Visible
+		public virtual bool Visible
 		{
 			get { return _visible; }
 

--- a/src/Myra/Systems/BaseSystem.cs
+++ b/src/Myra/Systems/BaseSystem.cs
@@ -1,0 +1,17 @@
+using Myra.Graphics2D.UI;
+
+namespace Myra.Systems
+{
+    public abstract class BaseSystem : ISystem
+    {
+        public Desktop Desktop { get; set; }
+        
+        public virtual void OnWidgetAddedToDesktop(Widget widget)
+        {
+            
+        }
+
+        public abstract void Update();
+        
+    }
+}

--- a/src/Myra/Systems/ISystem.cs
+++ b/src/Myra/Systems/ISystem.cs
@@ -1,0 +1,13 @@
+using Myra.Graphics2D.UI;
+
+namespace Myra.Systems
+{
+    public interface ISystem
+    {
+
+        Desktop Desktop { get; set; }
+        void OnWidgetAddedToDesktop(Widget widget);
+        void Update();
+        
+    }
+}

--- a/src/Myra/Systems/KeyboardTabSystem.cs
+++ b/src/Myra/Systems/KeyboardTabSystem.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework.Input;
+using Myra.Graphics2D.UI;
+
+namespace Myra.Systems
+{
+    public class KeyboardTabSystem : BaseSystem
+    {
+        private KeyboardState _lastState;
+        private readonly IList<Widget> _focusableWidgets = new List<Widget>();
+        private int _focussedIndex = -1;
+        private Widget _lastFocussedWidget;
+        private Widget _currentFocussedWidget;
+
+        public override void OnWidgetAddedToDesktop(Widget widget)
+        {
+            if (widget.AcceptsKeyboardFocus)
+            {
+                _focusableWidgets.Add(widget);
+            }
+
+            base.OnWidgetAddedToDesktop(widget);
+        }
+
+        public override void Update()
+        {
+            if (Keyboard.GetState().IsKeyDown(Keys.Tab) && _lastState.IsKeyUp(Keys.Tab))
+            {
+                FocusNextWidget();
+            }
+
+            _lastState = Keyboard.GetState();
+        }
+
+        private void FocusNextWidget()
+        {
+            if (_focusableWidgets.Count == 0) return;
+
+            var startFocus = _focussedIndex;
+
+            Widget nextFocusable;
+
+            do
+            {
+                _focussedIndex++;
+                ConstrainFocus();
+                nextFocusable = _focusableWidgets[_focussedIndex];
+            } while (_focussedIndex != startFocus && !CanFocusWidget(nextFocusable));
+
+            if (CanFocusWidget(nextFocusable))
+            {
+                if (_currentFocussedWidget != null)
+                {
+                    _currentFocussedWidget.IsKeyboardFocused = false;
+                }
+
+                _lastFocussedWidget = _currentFocussedWidget;
+                _currentFocussedWidget = nextFocusable;
+
+                _currentFocussedWidget.IsKeyboardFocused = true;
+                Desktop.FocusedKeyboardWidget = _currentFocussedWidget;
+            }
+        }
+
+        private static bool CanFocusWidget(Widget focusable) =>
+            focusable != null && focusable.Visible && focusable.Active &&
+            focusable.Enabled;
+
+        private void ConstrainFocus()
+        {
+            if (_focussedIndex >= _focusableWidgets.Count)
+                _focussedIndex = 0;
+            else if (_focussedIndex < 0)
+                _focussedIndex = _focusableWidgets.Count - 1;
+        }
+    }
+}


### PR DESCRIPTION
# What

New feature as mentioned in #128.

I've added systems to the desktop. So, every desktop can now have a set of systems that make use of the widgets that are on the desktop.

# How

* Added collection in the desktop that you can add new systems to.
* Created a keyboard tab system that checks for keyboard input and just tabs through any
keyboard focusable widgets.
* The biggest change is that Desktop now has an update method that needs to be called for the systems to do there thing.
* You add systems to the desktop through Desktop.AddSystem(); This will in turn call down through all of the widgets and add them to the system, the systems can then decide if they want any particular widget - in the case of the keyboard tab widget, it wants widgets that AcceptsKeyboardFocus.

# Tutorial

Set the widget to accept keyboard focus.
```
Widgets.Add(new ImageTextButton()
{
    ...
    AcceptsKeyboardFocus = true
});
```

Add the keyboard tab system to your desktop.
```
Desktop.AddSystem(new KeyboardTabSystem());
```

Make sure to update your Desktop in your Update.
```
Desktop.Update();
```

# Example

[Tabbing between widgets](https://i.imgur.com/ATcWYtc.gifv)

# Risk

I've tried to decouple it as much as I can from the original API, so I can't see anything that would be affected by it. The actual risk probably comes from how individual systems are implemented.
