### PR TITLE
Make scroll view touch friendly

### DIFF
--- a/samples/Myra.Samples.AllWidgets/AllWidgetsGame.cs
+++ b/samples/Myra.Samples.AllWidgets/AllWidgetsGame.cs
@@ -110,7 +110,7 @@ namespace Myra.Samples.AllWidgets
 #endif
 
 #if ANDROID
-			Desktop.WidgetGotKeyboardFocus += (s, a) =>
+			_desktop.WidgetGotKeyboardFocus += (s, a) =>
 			{
 				var asTextBox = a.Data as TextBox;
 				if (asTextBox == null)

--- a/samples/Myra.Samples.NonModalWindows/UI/MainPanel.cs
+++ b/samples/Myra.Samples.NonModalWindows/UI/MainPanel.cs
@@ -13,9 +13,9 @@ namespace Myra.Samples.NonModalWindows.UI
 		{
 			BuildUI();
 
-			_button1.PressedChanged += _button1_PressedChanged;
-			_button2.PressedChanged += _button2_PressedChanged;
-			_button3.PressedChanged += _button3_PressedChanged;
+			_button1.ToggledChanged += _button1_ToggledChanged;
+			_button2.ToggledChanged += _button2_ToggledChanged;
+			_button3.ToggledChanged += _button3_ToggledChanged;
 
 			_window1.Closed += (s, a) =>
 			{
@@ -40,7 +40,7 @@ namespace Myra.Samples.NonModalWindows.UI
 			_button3.IsPressed = true;
 		}
 
-		private void _button1_PressedChanged(object sender, System.EventArgs e)
+		private void _button1_ToggledChanged(object sender, System.EventArgs e)
 		{
 			if (_button1.IsPressed)
 			{
@@ -52,7 +52,7 @@ namespace Myra.Samples.NonModalWindows.UI
 			}
 		}
 
-		private void _button2_PressedChanged(object sender, System.EventArgs e)
+		private void _button2_ToggledChanged(object sender, System.EventArgs e)
 		{
 			if (_button2.IsPressed)
 			{
@@ -64,7 +64,7 @@ namespace Myra.Samples.NonModalWindows.UI
 			}
 		}
 
-		private void _button3_PressedChanged(object sender, System.EventArgs e)
+		private void _button3_ToggledChanged(object sender, System.EventArgs e)
 		{
 			if (_button3.IsPressed)
 			{

--- a/samples/Myra.Samples.NonModalWindows/UI/MainPanel.cs
+++ b/samples/Myra.Samples.NonModalWindows/UI/MainPanel.cs
@@ -42,7 +42,7 @@ namespace Myra.Samples.NonModalWindows.UI
 
 		private void _button1_ToggledChanged(object sender, System.EventArgs e)
 		{
-			if (_button1.IsPressed)
+			if (_button1.IsToggled)
 			{
 				_window1.Show(Desktop, new Point(100, 100));
 			}
@@ -54,7 +54,7 @@ namespace Myra.Samples.NonModalWindows.UI
 
 		private void _button2_ToggledChanged(object sender, System.EventArgs e)
 		{
-			if (_button2.IsPressed)
+			if (_button2.IsToggled)
 			{
 				_window2.Show(Desktop, new Point(400, 100));
 			}
@@ -66,7 +66,7 @@ namespace Myra.Samples.NonModalWindows.UI
 
 		private void _button3_ToggledChanged(object sender, System.EventArgs e)
 		{
-			if (_button3.IsPressed)
+			if (_button3.IsToggled)
 			{
 				_window3.Show(Desktop, new Point(200, 400));
 			}

--- a/src/Myra/Graphics2D/UI/ButtonBase.cs
+++ b/src/Myra/Graphics2D/UI/ButtonBase.cs
@@ -63,7 +63,7 @@ namespace Myra.Graphics2D.UI
 
         /// <summary>
         /// Indicates whether the current touch gesture started in this widget.
-        /// Similar to <see cref="Widget.TouchStayedInside"/> but keeps true also if the gesture leaves the widget's bounds.
+        /// Similar to <see cref="Widget.TouchStayedInside"/> but stays <see langword="true"/> also if the gesture leaves the widget's bounds.
         /// </summary>
         public bool IsPressed { get; set; }
 

--- a/src/Myra/Graphics2D/UI/ButtonBase.cs
+++ b/src/Myra/Graphics2D/UI/ButtonBase.cs
@@ -118,9 +118,9 @@ namespace Myra.Graphics2D.UI
 			PressedChanged.Invoke(this);
 		}
 
-		public override void OnTouchLeft()
+		public override void OnTouchLeft(HookableEventArgs args)
 		{
-			base.OnTouchLeft();
+			base.OnTouchLeft(args);
 
 			if (ReleaseOnTouchLeft && !Toggleable)
 			{

--- a/src/Myra/Graphics2D/UI/ComboBox.cs
+++ b/src/Myra/Graphics2D/UI/ComboBox.cs
@@ -39,7 +39,7 @@ namespace Myra.Graphics2D.UI
 		[XmlIgnore]
 		public bool IsExpanded
 		{
-			get { return InternalChild.IsPressed; }
+			get { return InternalChild.IsToggled; }
 		}
 
 		public override Desktop Desktop
@@ -94,7 +94,7 @@ namespace Myra.Graphics2D.UI
 				HorizontalAlignment = HorizontalAlignment.Stretch
 			};
 
-			InternalChild.PressedChanged += InternalChild_PressedChanged;
+			InternalChild.ToggledChanged += InternalChild_ToggledChanged;
 
 			_listBox._parentComboBox = this;
 			_listBox.Items.CollectionChanged += Items_CollectionChanged;
@@ -117,17 +117,17 @@ namespace Myra.Graphics2D.UI
 
 		private void DesktopOnContextMenuClosed(object sender, GenericEventArgs<Widget> genericEventArgs)
 		{
-			InternalChild.IsPressed = false;
+			InternalChild.IsToggled = false;
 		}
 
-		private void InternalChild_PressedChanged(object sender, EventArgs e)
+		private void InternalChild_ToggledChanged(object sender, EventArgs e)
 		{
 			if (_listBox.Items.Count == 0)
 			{
 				return;
 			}
 
-			if (InternalChild.IsPressed)
+			if (InternalChild.IsToggled)
 			{
 				if (_listBox.SelectedIndex == null && Items.Count > 0)
 				{
@@ -187,7 +187,7 @@ namespace Myra.Graphics2D.UI
 			{
 				InternalChild.Text = item.Text;
 				InternalChild.TextColor = item.Color ?? _listBox.ListBoxStyle.ListItemStyle.LabelStyle.TextColor;
-				((ImageTextButton)item.Widget).IsPressed = true;
+				((ImageTextButton)item.Widget).IsToggled = true;
 			}
 			else
 			{

--- a/src/Myra/Graphics2D/UI/Container.cs
+++ b/src/Myra/Graphics2D/UI/Container.cs
@@ -138,25 +138,25 @@ namespace Myra.Graphics2D.UI
 			ChildrenCopy.ProcessMouseMovement();
 		}
 
-		public override void OnTouchEntered()
+		public override void OnTouchEntered(HookableEventArgs args)
 		{
-			base.OnTouchEntered();
+			base.OnTouchEntered(args);
 
-			ChildrenCopy.ProcessTouchMovement();
+			ChildrenCopy.ProcessTouchMovement(args);
 		}
 
-		public override void OnTouchLeft()
+		public override void OnTouchLeft(HookableEventArgs args)
 		{
-			base.OnTouchLeft();
+			base.OnTouchLeft(args);
 
-			ChildrenCopy.ProcessTouchMovement();
+			ChildrenCopy.ProcessTouchMovement(args);
 		}
 
-		public override void OnTouchMoved()
+		public override void OnTouchMoved(HookableEventArgs args)
 		{
-			base.OnTouchMoved();
+			base.OnTouchMoved(args);
 
-			ChildrenCopy.ProcessTouchMovement();
+			ChildrenCopy.ProcessTouchMovement(args);
 		}
 
 		public override void OnTouchDown()

--- a/src/Myra/Graphics2D/UI/DebugOptionsWindow.cs
+++ b/src/Myra/Graphics2D/UI/DebugOptionsWindow.cs
@@ -13,34 +13,34 @@ namespace Myra.Graphics2D.UI
 
 			BuildUI();
 
-			_checkBoxWidgetFrames.IsPressed = MyraEnvironment.DrawWidgetsFrames;
-			_checkBoxWidgetFrames.PressedChanged += (s, a) =>
+			_checkBoxWidgetFrames.IsToggled = MyraEnvironment.DrawWidgetsFrames;
+			_checkBoxWidgetFrames.ToggledChanged += (s, a) =>
 			{
-				MyraEnvironment.DrawWidgetsFrames = _checkBoxWidgetFrames.IsPressed;
+				MyraEnvironment.DrawWidgetsFrames = _checkBoxWidgetFrames.IsToggled;
 			};
 
-			_checkBoxKeyboardFocusedWidgetFrame.IsPressed = MyraEnvironment.DrawKeyboardFocusedWidgetFrame;
-			_checkBoxKeyboardFocusedWidgetFrame.PressedChanged += (s, a) =>
+			_checkBoxKeyboardFocusedWidgetFrame.IsToggled = MyraEnvironment.DrawKeyboardFocusedWidgetFrame;
+			_checkBoxKeyboardFocusedWidgetFrame.ToggledChanged += (s, a) =>
 			{
-				MyraEnvironment.DrawKeyboardFocusedWidgetFrame = _checkBoxKeyboardFocusedWidgetFrame.IsPressed;
+				MyraEnvironment.DrawKeyboardFocusedWidgetFrame = _checkBoxKeyboardFocusedWidgetFrame.IsToggled;
 			};
 
-			_checkBoxMouseWheelFocusedWidgetFrame.IsPressed = MyraEnvironment.DrawMouseWheelFocusedWidgetFrame;
-			_checkBoxMouseWheelFocusedWidgetFrame.PressedChanged += (s, a) =>
+			_checkBoxMouseWheelFocusedWidgetFrame.IsToggled = MyraEnvironment.DrawMouseWheelFocusedWidgetFrame;
+			_checkBoxMouseWheelFocusedWidgetFrame.ToggledChanged += (s, a) =>
 			{
-				MyraEnvironment.DrawMouseWheelFocusedWidgetFrame = _checkBoxMouseWheelFocusedWidgetFrame.IsPressed;
+				MyraEnvironment.DrawMouseWheelFocusedWidgetFrame = _checkBoxMouseWheelFocusedWidgetFrame.IsToggled;
 			};
 
-			_checkBoxGlyphFrames.IsPressed = MyraEnvironment.DrawTextGlyphsFrames;
-			_checkBoxGlyphFrames.PressedChanged += (s, a) =>
+			_checkBoxGlyphFrames.IsToggled = MyraEnvironment.DrawTextGlyphsFrames;
+			_checkBoxGlyphFrames.ToggledChanged += (s, a) =>
 			{
-				MyraEnvironment.DrawTextGlyphsFrames = _checkBoxGlyphFrames.IsPressed;
+				MyraEnvironment.DrawTextGlyphsFrames = _checkBoxGlyphFrames.IsToggled;
 			};
 
-			_checkBoxDisableClipping.IsPressed = MyraEnvironment.DisableClipping;
-			_checkBoxDisableClipping.PressedChanged += (s, a) =>
+			_checkBoxDisableClipping.IsToggled = MyraEnvironment.DisableClipping;
+			_checkBoxDisableClipping.ToggledChanged += (s, a) =>
 			{
-				MyraEnvironment.DisableClipping = _checkBoxDisableClipping.IsPressed;
+				MyraEnvironment.DisableClipping = _checkBoxDisableClipping.IsToggled;
 			};
 		}
 
@@ -58,9 +58,9 @@ namespace Myra.Graphics2D.UI
 				Visible = true
 			};
 
-			optionsCheckBox.PressedChanged += (s, a) =>
+			optionsCheckBox.ToggledChanged += (s, a) =>
 			{
-				if (optionsCheckBox.IsPressed)
+				if (optionsCheckBox.IsToggled)
 				{
 					onEnabled();
 				}

--- a/src/Myra/Graphics2D/UI/Desktop.cs
+++ b/src/Myra/Graphics2D/UI/Desktop.cs
@@ -150,9 +150,10 @@ namespace Myra.Graphics2D.UI
 				}
 
 				_touchPosition = value;
-				TouchMoved.Invoke();
-
-				ChildrenCopy.ProcessTouchMovement();
+                HookableEventArgs args = new HookableEventArgs();
+                TouchMoved.Invoke(this, args);
+				ChildrenCopy.ProcessTouchMovement(args);
+                args.InvokeHookIfNotHandled();
 			}
 		}
 
@@ -387,7 +388,7 @@ namespace Myra.Graphics2D.UI
 
 		public event EventHandler MouseMoved;
 
-		public event EventHandler TouchMoved;
+		public event EventHandler<HookableEventArgs> TouchMoved;
 		public event EventHandler TouchDown;
 		public event EventHandler TouchUp;
 		public event EventHandler TouchDoubleClick;
@@ -1121,7 +1122,7 @@ namespace Myra.Graphics2D.UI
 			{
 				UpdateTouch();
 			}
-			catch (Exception)
+			catch (Exception e)
 			{
 			}
 #endif

--- a/src/Myra/Graphics2D/UI/Desktop.cs
+++ b/src/Myra/Graphics2D/UI/Desktop.cs
@@ -151,7 +151,7 @@ namespace Myra.Graphics2D.UI
 
 				_touchPosition = value;
                 HookableEventArgs args = new HookableEventArgs();
-                TouchMoved.Invoke(this, args);
+                TouchMoved?.Invoke(this, args);
 				ChildrenCopy.ProcessTouchMovement(args);
                 args.InvokeHookIfNotHandled();
 			}

--- a/src/Myra/Graphics2D/UI/Enums.cs
+++ b/src/Myra/Graphics2D/UI/Enums.cs
@@ -71,4 +71,14 @@ namespace Myra.Graphics2D.UI
 		/// </summary>
 		KeepAspectRatio
 	}
+
+    /// <summary>
+    /// Defines in which way the user is scrolling.
+    /// </summary>
+    public enum ScrollingType
+    {
+        Scrollbar,
+        MouseWheel,
+        Touch
+    }
 }

--- a/src/Myra/Graphics2D/UI/ImageButton.cs
+++ b/src/Myra/Graphics2D/UI/ImageButton.cs
@@ -76,11 +76,11 @@ namespace Myra.Graphics2D.UI
 			}
 		}
 
-		public override void OnPressedChanged()
+		public override void OnToggledChanged()
 		{
-			base.OnPressedChanged();
+			base.OnToggledChanged();
 
-			InternalChild.IsPressed = IsPressed;
+			InternalChild.IsPressed = IsToggled;
 		}
 	}
 }

--- a/src/Myra/Graphics2D/UI/ImageTextButton.cs
+++ b/src/Myra/Graphics2D/UI/ImageTextButton.cs
@@ -229,12 +229,12 @@ namespace Myra.Graphics2D.UI
 			ImageTextSpacing = style.ImageTextSpacing;
 		}
 
-		public override void OnPressedChanged()
+		public override void OnToggledChanged()
 		{
-			base.OnPressedChanged();
+			base.OnToggledChanged();
 
-			_image.IsPressed = IsPressed;
-			_textBlock.IsPressed = IsPressed;
+			_image.IsPressed = IsToggled;
+			_textBlock.IsPressed = IsToggled;
 		}
 
 		protected override void InternalSetStyle(Stylesheet stylesheet, string name)

--- a/src/Myra/Graphics2D/UI/ListBox.cs
+++ b/src/Myra/Graphics2D/UI/ListBox.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Xml.Serialization;
 using Myra.Graphics2D.UI.Styles;
@@ -194,17 +194,17 @@ namespace Myra.Graphics2D.UI
 			}
 		}
 
-		public override void OnTouchDown()
-		{
-			base.OnTouchDown();
+        public override void OnClick()
+        {
+            base.OnClick();
 
-			if (!InternalChild._verticalScrollingOn || !InternalChild._verticalScrollbarFrame.Contains(Desktop.TouchPosition))
-			{
-				ComboHideDropdown();
-			}
-		}
+            if (!InternalChild._verticalScrollingOn || !InternalChild._verticalScrollbarFrame.Contains(Desktop.TouchPosition))
+            {
+                ComboHideDropdown();
+            }
+        }
 
-		private void UpdateScrolling()
+        private void UpdateScrolling()
 		{
 			if (SelectedItem == null)
 			{

--- a/src/Myra/Graphics2D/UI/ListBox.cs
+++ b/src/Myra/Graphics2D/UI/ListBox.cs
@@ -86,7 +86,7 @@ namespace Myra.Graphics2D.UI
 					ImageTextSpacing = item.ImageTextSpacing
 				};
 
-				((ImageTextButton)widget).PressedChanged += ButtonOnPressed;
+				((ImageTextButton)widget).ToggledChanged += ButtonOnToggleChanged;
 			}
 			else
 			{
@@ -121,10 +121,10 @@ namespace Myra.Graphics2D.UI
 			}
 		}
 
-		private void ButtonOnPressed(object sender, EventArgs eventArgs)
+		private void ButtonOnToggleChanged(object sender, EventArgs eventArgs)
 		{
 			var item = (ImageTextButton)sender;
-			if (!item.IsPressed)
+			if (!item.IsToggled)
 			{
 				return;
 			}

--- a/src/Myra/Graphics2D/UI/ListButton.cs
+++ b/src/Myra/Graphics2D/UI/ListButton.cs
@@ -18,7 +18,7 @@ namespace Myra.Graphics2D.UI
 		{
 			// At least one list button should be pressed
 			return _selector.SelectionMode == SelectionMode.Multiple ||
-				!IsPressed;
+				!IsToggled;
 		}
 	}
 }

--- a/src/Myra/Graphics2D/UI/ListItem.cs
+++ b/src/Myra/Graphics2D/UI/ListItem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Xml.Serialization;
 
@@ -95,11 +95,7 @@ namespace Myra.Graphics2D.UI
 
 		public void FireSelectedChanged()
 		{
-			var ev = SelectedChanged;
-			if (ev != null)
-			{
-				ev(this, EventArgs.Empty);
-			}
-		}
+            SelectedChanged?.Invoke(this, EventArgs.Empty);
+        }
 	}
 }

--- a/src/Myra/Graphics2D/UI/ListItem.cs
+++ b/src/Myra/Graphics2D/UI/ListItem.cs
@@ -40,7 +40,7 @@ namespace Myra.Graphics2D.UI
 				var asButton = _widget as ImageTextButton;
 				if (asButton != null)
 				{
-					asButton.PressedChanged += (s, a) => FireSelectedChanged();
+					asButton.ToggledChanged += (s, a) => FireSelectedChanged();
 				}
 			}
 		}
@@ -57,7 +57,7 @@ namespace Myra.Graphics2D.UI
 					return false;
 				}
 
-				return asButton.IsPressed;
+				return asButton.IsToggled;
 			}
 
 			set
@@ -68,7 +68,7 @@ namespace Myra.Graphics2D.UI
 					return;
 				}
 
-				asButton.IsPressed = value;
+				asButton.IsToggled = value;
 			}
 		}
 

--- a/src/Myra/Graphics2D/UI/Menu.cs
+++ b/src/Myra/Graphics2D/UI/Menu.cs
@@ -349,7 +349,7 @@ namespace Myra.Graphics2D.UI
 
 			InternalChild.HoverIndexChanged += OnHoverIndexChanged;
 			InternalChild.SelectedIndexChanged += OnSelectedIndexChanged;
-			InternalChild.TouchUp += InternalChild_TouchUp;
+			InternalChild.Click += InternalChild_Click;
 
 			OpenMenuItem = null;
 
@@ -646,7 +646,7 @@ namespace Myra.Graphics2D.UI
 			}
 		}
 
-		private void InternalChild_TouchUp(object sender, EventArgs e)
+		private void InternalChild_Click(object sender, EventArgs e)
 		{
 			var menuItem = SelectedMenuItem;
 			if (menuItem != null && !menuItem.CanOpen)
@@ -666,7 +666,7 @@ namespace Myra.Graphics2D.UI
 			return Items[index.Value] as MenuItem;
 		}
 
-		private void Click(int? index)
+		private void SelectMenuItem(int? index)
 		{
 			var menuItem = GetMenuItem(index);
 			if (menuItem == null)
@@ -694,7 +694,7 @@ namespace Myra.Graphics2D.UI
 					var menuItem = Items[selectedIndex.Value] as MenuItem;
 					if (menuItem != null && !menuItem.CanOpen)
 					{
-						Click(menuItem.Index);
+						SelectMenuItem(menuItem.Index);
 						return;
 					}
 				}
@@ -714,7 +714,7 @@ namespace Myra.Graphics2D.UI
 
 					if (menuItem.UnderscoreChar == c)
 					{
-						Click(menuItem.Index);
+						SelectMenuItem(menuItem.Index);
 						return;
 					}
 				}

--- a/src/Myra/Graphics2D/UI/MenuItem.cs
+++ b/src/Myra/Graphics2D/UI/MenuItem.cs
@@ -336,13 +336,8 @@ namespace Myra.Graphics2D.UI
 
 		public void FireSelected()
 		{
-			var ev = Selected;
-
-			if (ev != null)
-			{
-				ev(this, EventArgs.Empty);
-			}
-		}
+            Selected?.Invoke(this, EventArgs.Empty);
+        }
 
 		protected internal override void OnIdChanged()
 		{
@@ -353,11 +348,7 @@ namespace Myra.Graphics2D.UI
 
 		protected void FireChanged()
 		{
-			var ev = Changed;
-			if (ev != null)
-			{
-				ev(this, EventArgs.Empty);
-			}
-		}
+            Changed?.Invoke(this, EventArgs.Empty);
+        }
 	}
 }

--- a/src/Myra/Graphics2D/UI/Properties/PropertyGrid.cs
+++ b/src/Myra/Graphics2D/UI/Properties/PropertyGrid.cs
@@ -95,9 +95,9 @@ namespace Myra.Graphics2D.UI.Properties
 
 				InternalChild.Widgets.Add(_mark);
 
-				_mark.PressedChanged += (sender, args) =>
+				_mark.ToggledChanged += (sender, args) =>
 				{
-					if (_mark.IsPressed)
+					if (_mark.IsToggled)
 					{
 						_propertyGrid.Visible = true;
 						parent._expandedCategories.Add(category);
@@ -117,7 +117,7 @@ namespace Myra.Graphics2D.UI.Properties
 
 				if (expanded)
 				{
-					_mark.IsPressed = true;
+					_mark.IsToggled = true;
 				}
 
 				var label = new Label(null)
@@ -144,7 +144,7 @@ namespace Myra.Graphics2D.UI.Properties
 					return;
 				}
 
-				_mark.IsPressed = !_mark.IsPressed;
+				_mark.IsToggled = !_mark.IsToggled;
 			}
 
 			public override void InternalRender(RenderContext context)
@@ -359,14 +359,14 @@ namespace Myra.Graphics2D.UI.Properties
 			var isChecked = (bool)value;
 			var cb = new CheckBox
 			{
-				IsPressed = isChecked
+				IsToggled = isChecked
 			};
 
 			if (hasSetter)
 			{
 				cb.Click += (sender, args) =>
 				{
-					SetValue(record, _object, cb.IsPressed);
+					SetValue(record, _object, cb.IsToggled);
 					FireChanged(propertyType.Name);
 				};
 			}
@@ -1164,7 +1164,7 @@ namespace Myra.Graphics2D.UI.Properties
 
 				if (_expandedCategories.Contains(category.Key))
 				{
-					subGrid.Mark.IsPressed = true;
+					subGrid.Mark.IsToggled = true;
 				}
 
 				var rp = new Proportion(ProportionType.Auto);

--- a/src/Myra/Graphics2D/UI/RadioButton.cs
+++ b/src/Myra/Graphics2D/UI/RadioButton.cs
@@ -28,11 +28,11 @@ namespace Myra.Graphics2D.UI
 			Toggleable = true;
 		}
 
-		public override void OnPressedChanged()
+		public override void OnToggledChanged()
 		{
-			base.OnPressedChanged();
+			base.OnToggledChanged();
 
-			if (IsPressed)
+			if (IsToggled)
 			{
 				foreach (var child in Parent.ChildrenCopy)
 				{
@@ -43,14 +43,14 @@ namespace Myra.Graphics2D.UI
 						continue;
 					}
 
-					asRadio.IsPressed = false;
+					asRadio.IsToggled = false;
 				}
 			}
 		}
 
 		protected override bool CanChangeToggleable(bool value)
 		{
-			return !IsPressed;
+			return !IsToggled;
 		}
 
 		protected override void InternalSetStyle(Stylesheet stylesheet, string name)

--- a/src/Myra/Graphics2D/UI/ScrollViewer.cs
+++ b/src/Myra/Graphics2D/UI/ScrollViewer.cs
@@ -666,7 +666,7 @@ namespace Myra.Graphics2D.UI
 			ScrollPosition = Point.Zero;
 		}
 
-		private void DesktopTouchMoved(object sender, EventArgs args)
+		private void DesktopTouchMoved(object sender, HookableEventArgs args)
 		{
 			if (!_startBoundsPos.HasValue)
 				return;
@@ -687,11 +687,11 @@ namespace Myra.Graphics2D.UI
 
 			if (_scrollingType == ScrollingType.Touch)
             {
-                MoveThumb(Point.Zero-delta);
+                args.AddHook(()=>MoveThumb(Point.Zero-delta));
             }
             else
             {
-                MoveThumb(delta);
+                args.AddHook(()=>MoveThumb(delta));
             }
         }
 

--- a/src/Myra/Graphics2D/UI/ScrollViewer.cs
+++ b/src/Myra/Graphics2D/UI/ScrollViewer.cs
@@ -21,7 +21,7 @@ namespace Myra.Graphics2D.UI
 		private bool _showHorizontalScrollBar, _showVerticalScrollBar;
 		internal Rectangle _horizontalScrollbarFrame, _horizontalScrollbarThumb;
 		internal Rectangle _verticalScrollbarFrame, _verticalScrollbarThumb;
-		private int? _startBoundsPos;
+		private Point? _startBoundsPos;
 		private int _thumbMaximumX, _thumbMaximumY;
 
 		[Browsable(false)]
@@ -397,7 +397,7 @@ namespace Myra.Graphics2D.UI
 			verticalScrollBarRect.Y += thumbPosition.Y;
 			if (ShowVerticalScrollBar && _verticalScrollingOn && verticalScrollBarRect.Contains(touchPosition))
 			{
-				_startBoundsPos = touchPosition.Y;
+				_startBoundsPos = touchPosition;
 				_dragDirection = DragDirection.Vertical;
                 _scrollingType = ScrollingType.Scrollbar;
                 return;
@@ -407,7 +407,7 @@ namespace Myra.Graphics2D.UI
             horizontalScrollBarRect.X += thumbPosition.X;
 			if (ShowHorizontalScrollBar && _horizontalScrollingOn && horizontalScrollBarRect.Contains(touchPosition))
 			{
-				_startBoundsPos = touchPosition.X;
+				_startBoundsPos = touchPosition;
 				_dragDirection = DragDirection.Horizontal;
                 _scrollingType = ScrollingType.Scrollbar;
                 return;
@@ -417,7 +417,7 @@ namespace Myra.Graphics2D.UI
             viewerRect.X += thumbPosition.X;
             if ((_verticalScrollingOn || _horizontalScrollingOn) && viewerRect.Contains(touchPosition))
             {
-                _startBoundsPos = touchPosition.X;
+                _startBoundsPos = touchPosition;
                 if (_verticalScrollingOn && _horizontalScrollingOn)
                 {
                     _dragDirection = DragDirection.Both;
@@ -676,13 +676,13 @@ namespace Myra.Graphics2D.UI
 			Point delta = new Point();
 			if (_dragDirection == DragDirection.Horizontal)
 			{
-				delta.X = (touchPosition.X - _startBoundsPos.Value) * ScrollMaximum.X / _thumbMaximumX;
-				_startBoundsPos = touchPosition.X;
+				delta.X = (touchPosition.X - _startBoundsPos.Value.X) * ScrollMaximum.X / _thumbMaximumX;
+				_startBoundsPos = new Point(touchPosition.X, _startBoundsPos.Value.Y);
 			}
 			if (_dragDirection == DragDirection.Vertical)
 			{
-				delta.Y = (touchPosition.Y - _startBoundsPos.Value) * ScrollMaximum.Y / _thumbMaximumY;
-				_startBoundsPos = touchPosition.Y;
+				delta.Y = (touchPosition.Y - _startBoundsPos.Value.Y) * ScrollMaximum.Y / _thumbMaximumY;
+				_startBoundsPos = new Point(_startBoundsPos.Value.X, touchPosition.Y);
 			}
 
 			if (_scrollingType == ScrollingType.Touch)

--- a/src/Myra/Graphics2D/UI/Slider.cs
+++ b/src/Myra/Graphics2D/UI/Slider.cs
@@ -236,13 +236,13 @@ namespace Myra.Graphics2D.UI
 			}
 		}
 
-		private void DesktopTouchMoved(object sender, EventArgs args)
+		private void DesktopTouchMoved(object sender, HookableEventArgs args)
 		{
 			if (!InternalChild.IsPressed)
 			{
 				return;
 			}
-
+            args.SetHandledFlag();
 			UpdateHint();
 		}
 	}

--- a/src/Myra/Graphics2D/UI/Slider.cs
+++ b/src/Myra/Graphics2D/UI/Slider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using Myra.Graphics2D.UI.Styles;
 using Myra.Utility;

--- a/src/Myra/Graphics2D/UI/Slider.cs
+++ b/src/Myra/Graphics2D/UI/Slider.cs
@@ -120,14 +120,16 @@ namespace Myra.Graphics2D.UI
 				if (Desktop != null)
 				{
 					Desktop.TouchMoved -= DesktopTouchMoved;
-				}
+					Desktop.TouchUp -= DesktopTouchUp;
+                }
 
 				base.Desktop = value;
 
 				if (Desktop != null)
 				{
 					Desktop.TouchMoved += DesktopTouchMoved;
-				}
+                    Desktop.TouchUp += DesktopTouchUp;
+                }
 			}
 		}
 
@@ -196,7 +198,7 @@ namespace Myra.Graphics2D.UI
 			InternalChild.IsPressed = true;
 		}
 
-		private void UpdateHint()
+        private void UpdateHint()
 		{
 			var hint = GetHint();
 			if (hint < 0)
@@ -245,5 +247,10 @@ namespace Myra.Graphics2D.UI
             args.SetHandledFlag();
 			UpdateHint();
 		}
-	}
+
+        private void DesktopTouchUp(object sender, EventArgs args)
+        {
+            InternalChild.IsPressed = false;
+        }
+    }
 }

--- a/src/Myra/Graphics2D/UI/SplitPane.cs
+++ b/src/Myra/Graphics2D/UI/SplitPane.cs
@@ -149,23 +149,19 @@ namespace Myra.Graphics2D.UI
 			}
 		}
 
-		private void HandleOnPressedChanged(object sender, EventArgs args)
-		{
-			var handle = (ImageButton)sender;
+        private void HandleOnTouchDown(object sender, EventArgs args)
+        {
+            _handleDown = (ImageButton)sender;
+            _mouseCoord = Orientation == Orientation.Horizontal
+                ? Desktop.TouchPosition.X - _handleDown.Bounds.X
+                : Desktop.TouchPosition.Y - _handleDown.Bounds.Y;
+        }
 
-			if (!handle.IsPressed)
-			{
-				_handleDown = null;
-				_mouseCoord = null;
-			}
-			else
-			{
-				_handleDown = (ImageButton)sender;
-				_mouseCoord = Orientation == Orientation.Horizontal
-					? Desktop.TouchPosition.X - _handleDown.Bounds.X
-					: Desktop.TouchPosition.Y - _handleDown.Bounds.Y;
-			}
-		}
+        private void HandleOnTouchUp(object sender, EventArgs args)
+        {
+            _handleDown = null;
+            _mouseCoord = null;
+        }
 
 		private void WidgetsOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
 		{
@@ -250,7 +246,8 @@ namespace Myra.Graphics2D.UI
 
 					handle.ApplyButtonStyle(HandleStyle);
 
-					handle.PressedChanged += HandleOnPressedChanged;
+                    handle.TouchDown += HandleOnTouchDown;
+                    handle.TouchUp += HandleOnTouchUp;
 
 					proportion = new Proportion(ProportionType.Auto);
 

--- a/src/Myra/Graphics2D/UI/SplitPane.cs
+++ b/src/Myra/Graphics2D/UI/SplitPane.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using Myra.Graphics2D.UI.Styles;
 using System.Xml.Serialization;
 using Myra.Attributes;
+using Myra.Utility;
 
 #if !STRIDE
 using Microsoft.Xna.Framework;
@@ -80,9 +81,9 @@ namespace Myra.Graphics2D.UI
 			return result;
 		}
 
-		public override void OnTouchMoved()
+		public override void OnTouchMoved(HookableEventArgs args)
 		{
-			base.OnTouchMoved();
+			base.OnTouchMoved(args);
 
 			if (_mouseCoord == null)
 			{
@@ -135,6 +136,7 @@ namespace Myra.Graphics2D.UI
 				firstProportion.Value = fp;
 				secondProportion.Value = fp2;
 				FireProportionsChanged();
+                args.SetHandledFlag();
 			}
 		}
 

--- a/src/Myra/Graphics2D/UI/TabItem.cs
+++ b/src/Myra/Graphics2D/UI/TabItem.cs
@@ -99,7 +99,7 @@ namespace Myra.Graphics2D.UI
 		{
 			get
 			{
-				return Button.IsPressed;
+				return Button.IsToggled;
 			}
 
 			set
@@ -109,7 +109,7 @@ namespace Myra.Graphics2D.UI
 					return;
 				}
 
-				Button.IsPressed = value;
+				Button.IsToggled = value;
 				FireSelected();
 			}
 		}

--- a/src/Myra/Graphics2D/UI/TextBox.cs
+++ b/src/Myra/Graphics2D/UI/TextBox.cs
@@ -1116,7 +1116,7 @@ namespace Myra.Graphics2D.UI
 			}
 		}
 
-		private void SetCursorByTouch()
+		private void SetCursorByTouch(HookableEventArgs args = null)
 		{
 			var bounds = ActualBounds;
 			var mousePos = Desktop.TouchPosition;
@@ -1131,6 +1131,7 @@ namespace Myra.Graphics2D.UI
 				if (glyphIndex != null)
 				{
 					UserSetCursorPosition(line.TextStartIndex + glyphIndex.Value);
+                    args?.SetHandledFlag();
 					if (_isTouchDown || Desktop.IsShiftDown)
 					{
 						UpdateSelection();
@@ -1146,26 +1147,27 @@ namespace Myra.Graphics2D.UI
 		{
 			base.OnTouchDown();
 
-			if (!Enabled)
-			{
-				return;
-			}
+            if (Enabled && Length != 0)
+            {
+                _isTouchDown = true;
+            }
+        }
 
-			if (Length == 0)
-			{
-				return;
-			}
+        public override void OnTouchUp()
+        {
+            base.OnTouchUp();
 
-			SetCursorByTouch();
+            if (_isTouchDown)
+            {
+                SetCursorByTouch();
+            }
+        }
 
-			_isTouchDown = true;
-		}
-
-		public override void OnTouchMoved()
+        public override void OnTouchMoved(HookableEventArgs args)
 		{
-			base.OnTouchMoved();
+			base.OnTouchMoved(args);
 
-			SetCursorByTouch();
+			SetCursorByTouch(args);
 		}
 
 		public override void OnTouchDoubleClick()
@@ -1476,7 +1478,7 @@ namespace Myra.Graphics2D.UI
 
 		private void DesktopTouchUp(object sender, EventArgs args)
 		{
-			_isTouchDown = false;
+            _isTouchDown = false;
 		}
 	}
 }

--- a/src/Myra/Graphics2D/UI/TextButton.cs
+++ b/src/Myra/Graphics2D/UI/TextButton.cs
@@ -79,12 +79,17 @@ namespace Myra.Graphics2D.UI
 			}
 		}
 
-		public override void OnPressedChanged()
-		{
-			base.OnPressedChanged();
+        public override void OnTouchDown()
+        {
+            base.OnTouchDown();
+            InternalChild.IsPressed = true;
+        }
 
-			InternalChild.IsPressed = IsPressed;
-		}
+        public override void OnTouchUp()
+        {
+            base.OnTouchDown();
+            InternalChild.IsPressed = false;
+        }
 
 		protected override void InternalSetStyle(Stylesheet stylesheet, string name)
 		{

--- a/src/Myra/Graphics2D/UI/TextButton.cs
+++ b/src/Myra/Graphics2D/UI/TextButton.cs
@@ -87,7 +87,7 @@ namespace Myra.Graphics2D.UI
 
         public override void OnTouchUp()
         {
-            base.OnTouchDown();
+            base.OnTouchUp();
             InternalChild.IsPressed = false;
         }
 

--- a/src/Myra/Graphics2D/UI/Tree.cs
+++ b/src/Myra/Graphics2D/UI/Tree.cs
@@ -179,9 +179,9 @@ namespace Myra.Graphics2D.UI
 			}
 		}
 
-		public override void OnTouchDown()
+		public override void OnClick()
 		{
-			base.OnTouchDown();
+			base.OnClick();
 
 			SetHoverRow(Desktop.TouchPosition);
 

--- a/src/Myra/Graphics2D/UI/Tree.cs
+++ b/src/Myra/Graphics2D/UI/Tree.cs
@@ -92,13 +92,13 @@ namespace Myra.Graphics2D.UI
 			{
 				Mark.Visible = true;
 				Label.Visible = true;
-				ChildNodesGrid.Visible = Mark.IsPressed;
+				ChildNodesGrid.Visible = Mark.IsToggled;
 			}
 			else
 			{
 				Mark.Visible = false;
 				Label.Visible = false;
-				Mark.IsPressed = true;
+				Mark.IsToggled = true;
 				ChildNodesGrid.Visible = true;
 			}
 		}

--- a/src/Myra/Graphics2D/UI/TreeNode.cs
+++ b/src/Myra/Graphics2D/UI/TreeNode.cs
@@ -22,9 +22,9 @@ namespace Myra.Graphics2D.UI
 
 		public bool IsExpanded
 		{
-			get { return _mark.IsPressed; }
+			get { return _mark.IsToggled; }
 
-			set { _mark.IsPressed = value; }
+			set { _mark.IsToggled = value; }
 		}
 
 		public Label Label
@@ -109,9 +109,9 @@ namespace Myra.Graphics2D.UI
 				VerticalAlignment = VerticalAlignment.Center
 			};
 
-			_mark.PressedChanged += (s, a) =>
+			_mark.ToggledChanged += (s, a) =>
 			{
-				_childNodesGrid.Visible = _mark.IsPressed;
+				_childNodesGrid.Visible = _mark.IsToggled;
 			};
 
 			InternalChild.Widgets.Add(_mark);

--- a/src/Myra/Graphics2D/UI/Widget.cs
+++ b/src/Myra/Graphics2D/UI/Widget.cs
@@ -894,9 +894,9 @@ namespace Myra.Graphics2D.UI
 		public event EventHandler MouseEntered;
 		public event EventHandler MouseMoved;
 
-		public event EventHandler TouchLeft;
-		public event EventHandler TouchEntered;
-		public event EventHandler TouchMoved;
+		public event EventHandler<HookableEventArgs> TouchLeft;
+		public event EventHandler<HookableEventArgs> TouchEntered;
+		public event EventHandler<HookableEventArgs> TouchMoved;
 		public event EventHandler TouchDown;
 		public event EventHandler TouchUp;
 		public event EventHandler TouchDoubleClick;
@@ -1443,22 +1443,22 @@ namespace Myra.Graphics2D.UI
 			MouseWheelChanged.Invoke(this, delta);
 		}
 
-		public virtual void OnTouchLeft()
+		public virtual void OnTouchLeft(HookableEventArgs args)
 		{
 			IsTouchInside = false;
-			TouchLeft.Invoke(this);
+			TouchLeft?.Invoke(this, args);
 		}
 
-		public virtual void OnTouchEntered()
+		public virtual void OnTouchEntered(HookableEventArgs args)
 		{
 			IsTouchInside = true;
-			TouchEntered.Invoke(this);
+			TouchEntered?.Invoke(this, args);
 		}
 
-		public virtual void OnTouchMoved()
+		public virtual void OnTouchMoved(HookableEventArgs args)
 		{
 			IsTouchInside = true;
-			TouchMoved.Invoke(this);
+			TouchMoved?.Invoke(this, args);
 		}
 
 		public virtual void OnTouchDown()
@@ -1612,7 +1612,7 @@ namespace Myra.Graphics2D.UI
 			}
 		}
 
-		private void DesktopOnTouchMoved(object sender, EventArgs args)
+		private void DesktopOnTouchMoved(object sender, HookableEventArgs args)
 		{
 			if (_startPos == null || !IsDraggable)
 			{

--- a/src/Myra/Graphics2D/UI/Widget.cs
+++ b/src/Myra/Graphics2D/UI/Widget.cs
@@ -908,6 +908,7 @@ namespace Myra.Graphics2D.UI
 		public event EventHandler<HookableEventArgs> TouchMoved;
 		public event EventHandler TouchDown;
 		public event EventHandler TouchUp;
+        public event EventHandler Click;
 		public event EventHandler TouchDoubleClick;
 
 		public event EventHandler KeyboardFocusChanged;
@@ -1502,15 +1503,7 @@ namespace Myra.Graphics2D.UI
 		{
             if (TouchStayedInside)
             {
-                if (Enabled && AcceptsKeyboardFocus)
-                {
-                    Desktop.FocusedKeyboardWidget = this;
-                }
-
-                if (Enabled && AcceptsMouseWheelFocus)
-                {
-                    Desktop.FocusedMouseWheelWidget = this;
-                }
+                OnClick();
             }
 
 			_startPos = null;
@@ -1518,6 +1511,20 @@ namespace Myra.Graphics2D.UI
 			IsTouchInside = false;
 			TouchUp.Invoke(this);
 		}
+
+        public virtual void OnClick()
+        {
+            if (Enabled && AcceptsKeyboardFocus)
+            {
+                Desktop.FocusedKeyboardWidget = this;
+            }
+
+            if (Enabled && AcceptsMouseWheelFocus)
+            {
+                Desktop.FocusedMouseWheelWidget = this;
+            }
+            Click.Invoke(this);
+        }
 
 		protected void FireKeyDown(Keys k)
 		{

--- a/src/Myra/Graphics2D/UI/Widget.cs
+++ b/src/Myra/Graphics2D/UI/Widget.cs
@@ -717,7 +717,16 @@ namespace Myra.Graphics2D.UI
 		[XmlIgnore]
 		public bool IsMouseInside { get; private set; }
 
-		[Browsable(false)]
+        /// <summary>
+        /// Indicates whether the touch gesture stayed inside this widget so far.
+        /// Is set to <see langword="true"/> if the touch gesture starts inside this widget.
+        /// Is set to <see langword="false"/> as soon as the touch gesture ends or the current position leaves the widget.
+        /// </summary>
+        [Browsable(false)]
+        [XmlIgnore]
+        public bool TouchStayedInside { get; private set; }
+
+        [Browsable(false)]
 		[XmlIgnore]
 		public bool IsTouchInside { get; private set; }
 
@@ -1445,6 +1454,7 @@ namespace Myra.Graphics2D.UI
 
 		public virtual void OnTouchLeft(HookableEventArgs args)
 		{
+            TouchStayedInside = false;
 			IsTouchInside = false;
 			TouchLeft?.Invoke(this, args);
 		}
@@ -1463,17 +1473,8 @@ namespace Myra.Graphics2D.UI
 
 		public virtual void OnTouchDown()
 		{
+            TouchStayedInside = true;
 			IsTouchInside = true;
-
-			if (Enabled && AcceptsKeyboardFocus)
-			{
-				Desktop.FocusedKeyboardWidget = this;
-			}
-
-			if (Enabled && AcceptsMouseWheelFocus)
-			{
-				Desktop.FocusedMouseWheelWidget = this;
-			}
 
 			var x = Bounds.X;
 			var y = Bounds.Y;
@@ -1499,7 +1500,21 @@ namespace Myra.Graphics2D.UI
 
 		public virtual void OnTouchUp()
 		{
+            if (TouchStayedInside)
+            {
+                if (Enabled && AcceptsKeyboardFocus)
+                {
+                    Desktop.FocusedKeyboardWidget = this;
+                }
+
+                if (Enabled && AcceptsMouseWheelFocus)
+                {
+                    Desktop.FocusedMouseWheelWidget = this;
+                }
+            }
+
 			_startPos = null;
+            TouchStayedInside = false;
 			IsTouchInside = false;
 			TouchUp.Invoke(this);
 		}

--- a/src/Myra/Utility/HookableEventArgs.cs
+++ b/src/Myra/Utility/HookableEventArgs.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Myra.Utility
+{
+    public class HookableEventArgs : EventArgs
+    {
+        public bool WasHandled { get; private set; }
+
+        private Action _hook;
+
+        public void SetHandledFlag()
+        {
+            WasHandled = true;
+        }
+
+        public void AddHook(Action hook)
+        {
+            _hook = hook;
+        }
+
+        public bool InvokeHookIfNotHandled()
+        {
+            if (_hook == null || WasHandled)
+            {
+                return false;
+            }
+
+            _hook.Invoke();
+            return true;
+        }
+    }
+}

--- a/src/Myra/Utility/InputHelpers.cs
+++ b/src/Myra/Utility/InputHelpers.cs
@@ -155,7 +155,7 @@ namespace Myra.Utility
 			}
 		}
 
-		public static void ProcessTouchMovement(this List<Widget> widgets)
+		public static void ProcessTouchMovement(this List<Widget> widgets, HookableEventArgs args)
 		{
 			// First run: call on OnTouchLeft on all widgets if it is required
 			for (var i = widgets.Count - 1; i >= 0; --i)
@@ -163,11 +163,11 @@ namespace Myra.Utility
 				var w = widgets[i];
 				if (!w.ContainsTouch && w.IsTouchInside)
 				{
-					w.OnTouchLeft();
+					w.OnTouchLeft(args);
 				}
 			}
 
-			// Second run: OnTouchEnter/OnTouchMoved
+            // Second run: OnTouchEnter/OnTouchMoved
 			for (var i = widgets.Count - 1; i >= 0; --i)
 			{
 				var w = widgets[i];
@@ -179,12 +179,12 @@ namespace Myra.Utility
 
 					if (isTouchOver && !wasTouchOver)
 					{
-						w.OnTouchEntered();
+						w.OnTouchEntered(args);
 					}
 
 					if (isTouchOver && wasTouchOver)
 					{
-						w.OnTouchMoved();
+						w.OnTouchMoved(args);
 					}
 
 					if (w.Desktop != null && !w.FallsThrough(w.Desktop.TouchPosition))


### PR DESCRIPTION
Adds the capability to scroll in a ScrollViewer by drag touch gesture. In my first tests the scrolling is working.
However the interaction is still interpreted by the children widgets (e.g. I can scroll the ScrollViewer and drag a Slider inside the ScrollViewer at the same time). Can someone point me where I can fix this?

I tried to keep the overall architecture of ScrollViewer as it is. If everything works out and you are fine with the changes @rds1983 I think this should solve https://github.com/rds1983/Myra/issues/87 .