### PR TITLE
Stops TextBox that is ReadOnly from getting keyboard focus

### DIFF
--- a/src/Myra/Graphics2D/UI/TextBox.cs
+++ b/src/Myra/Graphics2D/UI/TextBox.cs
@@ -36,6 +36,7 @@ namespace Myra.Graphics2D.UI
 		private bool _suppressRedoStackReset = false;
 		private string _text;
 		private string _hintText;
+		private bool _readOnly;
 		private bool _passwordField;
 		private bool _isTouchDown;
 
@@ -204,7 +205,19 @@ namespace Myra.Graphics2D.UI
 		[DefaultValue(false)]
 		public bool Readonly
 		{
-			get; set;
+			get
+			{
+				return _readOnly;
+			}
+			set
+			{
+				_readOnly = value;
+				AcceptsKeyboardFocus = !_readOnly;
+				if (!AcceptsKeyboardFocus && Desktop?.FocusedKeyboardWidget == this)
+				{
+					Desktop.FocusedKeyboardWidget = null;
+				}
+			}
 		}
 
 		[Category("Behavior")]


### PR DESCRIPTION
My read only text boxes were getting focused on Tab and had a blinking cursor.

I didn't think it made much sense so I changed the behavior. I'm not sure if this is necessarily a bug though, just how I prefer the behavior.