### PR TITLE
Stow away non-parsed MML attributes

### DIFF
--- a/src/Myra/MML/BaseObject.cs
+++ b/src/Myra/MML/BaseObject.cs
@@ -31,6 +31,13 @@ namespace Myra.MML
 		}
 
 		/// <summary>
+		/// Holds custom user attributes not mapped to the object
+		/// </summary>
+		[XmlIgnore]
+		[Browsable(false)]
+		public Dictionary<string, string> UserData { get; private set; } = new Dictionary<string, string>();
+
+		/// <summary>
 		/// External files used by this object
 		/// </summary>
 		[XmlIgnore]

--- a/src/Myra/MML/LoadContext.cs
+++ b/src/Myra/MML/LoadContext.cs
@@ -31,6 +31,8 @@ namespace Myra.MML
 		public Assembly Assembly = typeof(Widget).Assembly;
 		public Func<Type, string, object> ResourceGetter = null;
 
+		private const string UserDataAttributePrefix = "_";
+
 		public void Load(object obj, XElement el)
 		{
 			var type = obj.GetType();
@@ -120,6 +122,14 @@ namespace Myra.MML
 					}
 
 					property.SetValue(obj, value);
+				}
+				else
+				{
+					// Stow away custom user attributes
+					if (propertyName.StartsWith(UserDataAttributePrefix) && baseObject != null)
+					{
+						baseObject.UserData.Add(propertyName, attr.Value);
+					}
 				}
 			}
 


### PR DESCRIPTION
Stores all user defined attributes on an MML element that derives from `BaseObject` into a dictionary on the object itself. A custom attribute must start with "_".

```
Project p = Project.LoadFromXml(@"
	<Project>
		<Panel>
			<Label Text=""This is static text"" Margin=""10, 5, 0, 0"" Id=""StaticText1"" _MyCustomAttribute=""foobar"" _Text=""Hallo"" />
		</Panel>
	 </Project>
");

var attrVal = p.Root
   .FindWidgetById("StaticText1")
   .UserData["_MyCustomAttribute"]; // foobar
```