### PR TITLE
Apply tranformation when calculating clipping rectangle

### DIFF
--- a/src/Myra/Graphics2D/UI/Widget.cs
+++ b/src/Myra/Graphics2D/UI/Widget.cs
@@ -1006,6 +1006,17 @@ namespace Myra.Graphics2D.UI
 
 				context.Flush();
 
+				if (context.SpriteBatchBeginParams.TransformMatrix.HasValue)
+				{
+					var pos = new Point(newScissorRectangle.X, newScissorRectangle.Y).ToVector2();
+					var size = new Point(newScissorRectangle.Width, newScissorRectangle.Height).ToVector2();
+
+					pos = Vector2.Transform(pos, context.SpriteBatchBeginParams.TransformMatrix.Value);
+					size = Vector2.Transform(size, context.SpriteBatchBeginParams.TransformMatrix.Value);
+
+					newScissorRectangle = new Rectangle(pos.ToPoint(), size.ToPoint());
+				}
+
 				CrossEngineStuff.SetScissor(newScissorRectangle);
 			}
 


### PR DESCRIPTION
I've been testing Myra on Android and iOS which has required scaling of the UI elements using TransformMatrix to make them bigger on the HD mobile displays. I noticed that Textboxes did not seem to render properly and tracked it down to the clipping when ClipToBounds is set to true.  I added this change which seems to have fixed it without breaking the other controls on my page.  Hopefully this helps!