### PR TITLE
Added LayoutScale environment setting to apply overall scaling to adjust the UI size and spacing on mobile devices

### DIFF
--- a/src/Myra/Graphics2D/UI/Desktop.cs
+++ b/src/Myra/Graphics2D/UI/Desktop.cs
@@ -650,6 +650,11 @@ namespace Myra.Graphics2D.UI
 				{
 					Batch = spriteBatch
 				};
+
+				if(MyraEnvironment.LayoutScale.HasValue)
+                {
+					_renderContext.SpriteBatchBeginParams.TransformMatrix = Matrix.CreateScale(MyraEnvironment.LayoutScale.Value);
+				}
 			}
 		}
 

--- a/src/Myra/Graphics2D/UI/LayoutUtils.cs
+++ b/src/Myra/Graphics2D/UI/LayoutUtils.cs
@@ -9,8 +9,11 @@ namespace Myra.Graphics2D.UI
 	public static class LayoutUtils
 	{
 		public static Rectangle Align(Point containerSize, Point controlSize, HorizontalAlignment horizontalAlignment,
-			VerticalAlignment verticalAlignment)
+			VerticalAlignment verticalAlignment, bool isTopLevel = false)
 		{
+			if (isTopLevel && MyraEnvironment.LayoutScale.HasValue)
+				containerSize = new Point((int) (containerSize.X / MyraEnvironment.LayoutScale), (int) (containerSize.Y / MyraEnvironment.LayoutScale));
+
 			var result = new Rectangle
 			{
 				Width = controlSize.X,

--- a/src/Myra/Graphics2D/UI/Widget.cs
+++ b/src/Myra/Graphics2D/UI/Widget.cs
@@ -1255,7 +1255,7 @@ namespace Myra.Graphics2D.UI
 				}
 
 				// Align
-				var controlBounds = LayoutUtils.Align(containerSize, size, HorizontalAlignment, VerticalAlignment);
+				var controlBounds = LayoutUtils.Align(containerSize, size, HorizontalAlignment, VerticalAlignment, Parent == null);
 				controlBounds.Offset(_containerBounds.Location);
 
 				controlBounds.Offset(Left, Top);

--- a/src/Myra/MyraEnvironment.cs
+++ b/src/Myra/MyraEnvironment.cs
@@ -126,5 +126,10 @@ namespace Myra
 		}
 
 		internal static string InternalClipboard;
+
+		/// <summary>
+		/// Applies an overall scaling factor to adjust the size and spacing of widgets on devices with high definition displays
+		/// </summary>
+		public static float? LayoutScale { get; set; }
 	}
 }


### PR DESCRIPTION
I'm not so sure about this one but it's maybe worth a look...

Widgets which look OK on a desktop app are rendering very small on mobile devices due to the pixel density of their small displays.  I was able to address this to some degree using the SpriteBatchBeginParams.TransformMatrix but there was an impact on layouts which centred the widgets either horizontally or vertically.  This was due to the container size calculation not taking into consideration the scale factor applied using SpriteBatchBeginParams.TransformMatrix.  On my app I fixed this by updating Myra to add an overall scaling factor which is just a single float which indicates how much to scale the UI by when drawing.  This scale factor is then used when calculating the container size for the top level container on the UI.  The scale factor can be set depending on the display properties of the hardware running the game. 