### PR TITLE
Expose the TreeNode grid to be able to add custom widgets

### DIFF
--- a/src/Myra/Graphics2D/UI/TreeNode.cs
+++ b/src/Myra/Graphics2D/UI/TreeNode.cs
@@ -68,6 +68,11 @@ namespace Myra.Graphics2D.UI
 			get { return _childNodesGrid.Widgets.Count; }
 		}
 
+		public Grid Grid
+		{
+			get { return InternalChild; }
+		}
+
 		internal Rectangle RowBounds { get; set; }
 
 		internal bool RowVisible { get; set; }

--- a/src/Myra/Graphics2D/UI/TreeNode.cs
+++ b/src/Myra/Graphics2D/UI/TreeNode.cs
@@ -68,6 +68,8 @@ namespace Myra.Graphics2D.UI
 			get { return _childNodesGrid.Widgets.Count; }
 		}
 
+		[XmlIgnore]
+		[Browsable(false)]
 		public Grid Grid
 		{
 			get { return InternalChild; }


### PR DESCRIPTION
I'm looking at having tree nodes with more than just a label on it as it's a bit limiting. I can't derive from Tree and TreeNode to create my own without changing a lot of private and internal fields, however exposing the InternalChild Grid object allows me to very easily modify the node contents (adding an image, button etc).

I know I'm exposing an internal property, but the other alternative is to make the Tree/TreeNode classes inherit-friendly which exposes a lot more fields. What do you think?