### PR TITLE
[MyraPad] Simplify converting primitives to literals

### DIFF
--- a/src/MyraPad/ExporterCS.cs
+++ b/src/MyraPad/ExporterCS.cs
@@ -20,12 +20,13 @@ using XNAssets.Utility;
 
 namespace MyraPad
 {
-	public class ExporterCS
+	public class ExporterCS : IDisposable
 	{
 		private readonly Project _project;
 		private readonly Dictionary<string, int> ids = new Dictionary<string, int>();
 		private readonly StringBuilder sbFields = new StringBuilder();
 		private readonly StringBuilder sbBuild = new StringBuilder();
+		private readonly PrimitiveConverter converter = new PrimitiveConverter();
 		private bool isFirst = true;
 
 		public ExporterCS(Project project)
@@ -273,10 +274,9 @@ namespace MyraPad
 			return result;
 		}
 
-		private static string BuildPropertyCode(PropertyInfo property, object o, string idPrefix)
+		private string BuildPropertyCode(PropertyInfo property, object o, string idPrefix)
 		{
 			var sb = new StringBuilder();
-			var converter = new PrimitiveConverter();
 
 			var value = property.GetValue(o);
 
@@ -337,8 +337,6 @@ namespace MyraPad
 					sb.Append(");");
 				}
 			}
-
-			converter.Dispose();
 
 			return sb.ToString();
 		}
@@ -463,7 +461,9 @@ namespace MyraPad
 
 			return result.ToArray();
 		}
-	}
+
+        public void Dispose() => converter.Dispose();
+    }
 
 	class PrimitiveConverter : IDisposable
 	{

--- a/src/MyraPad/Studio.cs
+++ b/src/MyraPad/Studio.cs
@@ -1259,16 +1259,17 @@ namespace MyraPad
 
 					UpdateSource();
 
-					var export = new ExporterCS(Instance.Project);
-
-					var strings = new List<string>
+					using (var export = new ExporterCS(Instance.Project))
 					{
-						"Success. Following files had been written:"
-					};
-					strings.AddRange(export.Export());
+						var strings = new List<string>
+						{
+							"Success. Following files had been written:"
+						};
+						strings.AddRange(export.Export());
 
-					var msg = Dialog.CreateMessageBox("Export To C#", string.Join("\n", strings));
-					msg.ShowModal(_desktop);
+						var msg = Dialog.CreateMessageBox("Export To C#", string.Join("\n", strings));
+						msg.ShowModal(_desktop);
+					}
 				}
 				catch (Exception ex)
 				{


### PR DESCRIPTION
A more convenient way to turn primitive values into C# literals. This fixes various edge cases such as cultures with decimal comma, NaN/Infinity, the f prefix for floats, newlines in strings etc.

Sorry about the unrelated lines in the diff, I pressed "spaces to tabs" at the end and they got fixed as well