### PR TITLE
apply layoutScale on Window centering

### DIFF
--- a/src/Myra/Graphics2D/UI/Window.cs
+++ b/src/Myra/Graphics2D/UI/Window.cs
@@ -217,8 +217,9 @@ namespace Myra.Graphics2D.UI
 		public void CenterOnDesktop()
 		{
 			var size = Bounds.Size();
-			Left = (ContainerBounds.Width - size.X) / 2;
-			Top = (ContainerBounds.Height - size.Y) / 2;
+			var layoutScale = MyraEnvironment.LayoutScale.GetValueOrDefault(1);
+			Left = ((int)(ContainerBounds.Width / layoutScale) - size.X) / 2;
+			Top = ((int)(ContainerBounds.Height / layoutScale) - size.Y) / 2;
 		}
 
 		public override void OnTouchDown()


### PR DESCRIPTION
If you set the MyraEnvironment.LayoutScale, then it is applied to overall scale and positioning, but not in the case of Window.CenterOnDesktop. Thus, the window is placed to a wrong position.

https://github.com/rds1983/Myra/issues/271