### PR TITLE
Extending xmmp features to ensure hardcoding is (less) necessary

### DIFF
--- a/src/Myra/Graphics2D/UI/ImageTextButton.cs
+++ b/src/Myra/Graphics2D/UI/ImageTextButton.cs
@@ -29,6 +29,21 @@ namespace Myra.Graphics2D.UI
 		private readonly Label _label;
 		private TextPositionEnum _textPosition;
 
+
+		private string _l18nText;
+		public string L18nTextKey 
+		{
+			get 
+			{
+				return _l18nText;	
+            }
+			set 
+			{
+				_l18nText = value;
+				Text = Project.Localize.Invoke(value);
+			}
+		}
+
 		[Category("Appearance")]
 		[DefaultValue(null)]
 		public string Text

--- a/src/Myra/Graphics2D/UI/ImageTextButton.cs
+++ b/src/Myra/Graphics2D/UI/ImageTextButton.cs
@@ -40,7 +40,7 @@ namespace Myra.Graphics2D.UI
 			set 
 			{
 				_l18nText = value;
-				Text = Project.Localize.Invoke(value);
+				Text = Project.Localize?.Invoke(value) ?? value;
 			}
 		}
 

--- a/src/Myra/Graphics2D/UI/Label.cs
+++ b/src/Myra/Graphics2D/UI/Label.cs
@@ -54,7 +54,7 @@ namespace Myra.Graphics2D.UI
 			set 
 			{
 				_l18nText = value;
-				Text = Project.Localize.Invoke(value);
+				Text = Project.Localize?.Invoke(value) ?? value;
 			}
 		}
 

--- a/src/Myra/Graphics2D/UI/Label.cs
+++ b/src/Myra/Graphics2D/UI/Label.cs
@@ -44,6 +44,20 @@ namespace Myra.Graphics2D.UI
 			}
 		}
 
+		private string _l18nText;
+		public string L18nTextKey 
+		{
+			get 
+			{
+				return _l18nText;
+			}
+			set 
+			{
+				_l18nText = value;
+				Text = Project.Localize.Invoke(value);
+			}
+		}
+
 		[Category("Appearance")]
 		[DefaultValue(null)]
 		public string Text

--- a/src/Myra/Graphics2D/UI/Project.cs
+++ b/src/Myra/Graphics2D/UI/Project.cs
@@ -34,6 +34,8 @@ namespace Myra.Graphics2D.UI
 		public const string DefaultColumnProportionName = "DefaultColumnProportion";
 		public const string DefaultRowProportionName = "DefaultRowProportion";
 
+		public static Func<string, string> Localize = null;
+
 		private static readonly Dictionary<string, string> LegacyClassNames = new Dictionary<string, string>();
 
 		private readonly ExportOptions _exportOptions = new ExportOptions();
@@ -196,7 +198,7 @@ namespace Myra.Graphics2D.UI
 			return xDoc.ToString();
 		}
 
-		public static Project LoadFromXml(XDocument xDoc, IAssetManager assetManager, Stylesheet stylesheet)
+		public static Project LoadFromXml<T>(XDocument xDoc, IAssetManager assetManager, Stylesheet stylesheet, T handler) where T : class 
 		{
 			var result = new Project
 			{
@@ -204,22 +206,37 @@ namespace Myra.Graphics2D.UI
 			};
 
 			var loadContext = result.CreateLoadContext(assetManager);
-			loadContext.Load(result, xDoc.Root);
+			loadContext.Load(result, xDoc.Root, handler);
 
 			return result;
 		}
 
+		public static Project LoadFromXml<T>(string data, IAssetManager assetManager, Stylesheet stylesheet, T handler) where T : class
+		{
+			return LoadFromXml(XDocument.Parse(data), assetManager, stylesheet, handler);
+		}
+
+		public static Project LoadFromXml<T>(string data, T handler) where T : class
+		{
+			return LoadFromXml(data, null, Stylesheet.Current, handler);
+		}
+
+		public static Project LoadFromXml(XDocument xDoc, IAssetManager assetManager, Stylesheet stylesheet)
+		{
+			return LoadFromXml<object>(xDoc, assetManager, stylesheet, null);
+		}
+
 		public static Project LoadFromXml(string data, IAssetManager assetManager, Stylesheet stylesheet)
 		{
-			return LoadFromXml(XDocument.Parse(data), assetManager, stylesheet);
+			return LoadFromXml<object>(XDocument.Parse(data), assetManager, stylesheet, null);
 		}
 
 		public static Project LoadFromXml(string data, IAssetManager assetManager = null)
 		{
-			return LoadFromXml(data, assetManager, Stylesheet.Current);
+			return LoadFromXml<object>(data, assetManager, Stylesheet.Current, null);
 		}
 
-		public static object LoadObjectFromXml(string data, IAssetManager assetManager, Stylesheet stylesheet)
+		public static object LoadObjectFromXml<T>(string data, IAssetManager assetManager, Stylesheet stylesheet, T handler) where T : class
 		{
 			XDocument xDoc = XDocument.Parse(data);
 
@@ -252,10 +269,15 @@ namespace Myra.Graphics2D.UI
 
 			var item = CreateItem(itemType, xDoc.Root, stylesheet);
 			var loadContext = CreateLoadContext(assetManager, stylesheet);
-			loadContext.Load(item, xDoc.Root);
+			loadContext.Load(item, xDoc.Root, handler);
 
 			return item;
 		}
+
+		public static object LoadObjectFromXml(string data, IAssetManager assetManager, Stylesheet stylesheet)
+        {
+			return LoadObjectFromXml<object>(data, assetManager, stylesheet, null);
+        }
 
 		public object LoadObjectFromXml(string data, IAssetManager assetManager)
 		{

--- a/src/Myra/Graphics2D/UI/SelectableItem.cs
+++ b/src/Myra/Graphics2D/UI/SelectableItem.cs
@@ -50,7 +50,7 @@ namespace Myra.Graphics2D.UI
 			set 
 			{
 				_l18nText = value;
-				Text = Project.Localize.Invoke(value);
+				Text = Project.Localize?.Invoke(value) ?? value;
 			}
 		}
 

--- a/src/Myra/Graphics2D/UI/SelectableItem.cs
+++ b/src/Myra/Graphics2D/UI/SelectableItem.cs
@@ -40,6 +40,20 @@ namespace Myra.Graphics2D.UI
 			}
 		}
 
+		private string _l18nText;
+		public string L18nTextKey 
+		{
+			get 
+			{
+				return _l18nText;
+			}
+			set 
+			{
+				_l18nText = value;
+				Text = Project.Localize.Invoke(value);
+			}
+		}
+
 		[DefaultValue(null)]
 		public Color? Color
 		{

--- a/src/Myra/Graphics2D/UI/Styles/Stylesheet.cs
+++ b/src/Myra/Graphics2D/UI/Styles/Stylesheet.cs
@@ -641,7 +641,7 @@ namespace Myra.Graphics2D.UI.Styles
 				Colors = colors
 			};
 
-			loadContext.Load(result, xDoc.Root);
+			loadContext.Load<object>(result, xDoc.Root, null);
 
 			return result;
 		}


### PR DESCRIPTION
1. Events can now be called in a xmmp file

Project.LoadFromXml now has extra functions which allow one to enter a class instance to serve as eventhandler.

`Project.LoadFromXml(File.ReadAllText("UI/MainMenuScreen.xmmp"), this);`
`public void ContinueButton_Click(object sender, EventArgs e)
{
     HasSceneEnded = true;
}`

in the xmmp you can enter public non-static methods that serve as the receipients for the events.

`<Button Click="ContinueButton_Click" />`

2. You can now localize texts using xmmp

First, you have to enter the Func<string, string> in Project (static variable) which determines how a string is localized.
In my own personal project I localize using .resx files and the following line of code is made to reflect that. However, other people may want to localize differently (SQLite, json, etc) so they can enter the lambda as they see fit.

This line of code should be implemented in the implementation of the Game class. There will not be any errors in your runtime if this isn't implemented, unless you are going to use the localize texts property.

` Project.Localize = (key) => L18nManager.GetText(key);`

Then, in xmmp

`<Button Click="ContinueButton_Click" L18nTextKey="continue"   />`

Do note that L18nTextKey will in its set property override the Text property, so using this one alongside Text will likely not result in a desired outcome.

3. Result:

The following code: 
`            
Constants.GUIRenderer.Root = Project.LoadFromXml<MainMenuScene>(File.ReadAllText("UI/MainMenuScreen.xmmp"), this).Root;
         
            // populate main screen
            _title = Constants.GUIRenderer.Root.FindWidgetById("TitleText") as Label;
            _title.Text = L18nManager.GetText("game_title");

            _continueButton = Constants.GUIRenderer.Root.FindWidgetById("ContinueButton") as ImageTextButton;
            _continueButton.Text = L18nManager.GetText("continue");
            _continueButton.Click += ContinueButton_Click;

            _newGameButton = Constants.GUIRenderer.Root.FindWidgetById("NewGameButton") as ImageTextButton;
            _newGameButton.Text = L18nManager.GetText("new_game");
            _newGameButton.Click += NewGameButton_Click;

            _loadGameButton = Constants.GUIRenderer.Root.FindWidgetById("LoadGameButton") as ImageTextButton;
            _loadGameButton.Text = L18nManager.GetText("load_game");
            _loadGameButton.Click += LoadGameButton_Click;

            _optionsButton = Constants.GUIRenderer.Root.FindWidgetById("OptionsButton") as ImageTextButton;
            _optionsButton.Text = L18nManager.GetText("options");
            _optionsButton.Click += OptionsButton_Click;

            _quitButton = Constants.GUIRenderer.Root.FindWidgetById("QuitButton") as ImageTextButton;
            _quitButton.Text = L18nManager.GetText("quit");
            _quitButton.Click += QuitButton_Click;

            UIRoot = Constants.GUIRenderer.Root;`

to this:

`            Constants.GUIRenderer.Root = Project.LoadFromXml(File.ReadAllText("UI/MainMenuScreen.xmmp"), this).Root;
            UIRoot = Constants.GUIRenderer.Root;
`