### PR TITLE
Add TabSelectorPosition to TabControl

### DIFF
--- a/src/Myra/Graphics2D/UI/Enums.cs
+++ b/src/Myra/Graphics2D/UI/Enums.cs
@@ -72,4 +72,12 @@ namespace Myra.Graphics2D.UI
 		/// </summary>
 		KeepAspectRatio
 	}
+	
+	public enum TabSelectorPosition
+	{
+		Top,
+		Right,
+		Bottom,
+		Left
+	}
 }

--- a/src/Myra/Graphics2D/UI/Styles/TabControlStyle.cs
+++ b/src/Myra/Graphics2D/UI/Styles/TabControlStyle.cs
@@ -22,6 +22,11 @@
 			get; set;
 		}
 
+		public TabSelectorPosition TabSelectorPosition
+		{
+			get; set;
+		}
+
 		public TabControlStyle()
 		{
 		}
@@ -33,6 +38,8 @@
 
 			ButtonSpacing = style.ButtonSpacing;
 			HeaderSpacing = style.HeaderSpacing;
+
+			TabSelectorPosition = style.TabSelectorPosition;
 		}
 
 		public override WidgetStyle Clone()

--- a/src/Myra/Graphics2D/UI/TabControl.cs
+++ b/src/Myra/Graphics2D/UI/TabControl.cs
@@ -147,25 +147,26 @@ namespace Myra.Graphics2D.UI
 
 		public TabControl(string styleName = Stylesheet.DefaultStyleName) : base(new Grid())
 		{
-			// First row contains button
-			InternalChild.RowsProportions.Add(new Proportion());
+			HorizontalAlignment = HorizontalAlignment.Left;
+			VerticalAlignment = VerticalAlignment.Top;
 
 			_gridButtons = new Grid();
-			InternalChild.Widgets.Add(_gridButtons);
-
-			// Second row contains content
-			InternalChild.RowsProportions.Add(new Proportion(ProportionType.Fill));
-
 			_panelContent = new SingleItemContainer<Widget>()
 			{
 				GridRow = 1,
 				HorizontalAlignment = HorizontalAlignment.Stretch,
 				VerticalAlignment = VerticalAlignment.Stretch
 			};
-			InternalChild.Widgets.Add(_panelContent);
 
-			HorizontalAlignment = HorizontalAlignment.Left;
-			VerticalAlignment = VerticalAlignment.Top;
+			// Default to Top selector position:
+			_buttonProportions = _gridButtons.ColumnsProportions;
+			_contentProportions = InternalChild.RowsProportions;
+
+			// button, then content
+			_contentProportions.Add(new Proportion());
+			_contentProportions.Add(new Proportion(ProportionType.Fill));
+			InternalChild.Widgets.Add(_gridButtons);
+			InternalChild.Widgets.Add(_panelContent);
 
 			SetStyle(styleName);
 		}


### PR DESCRIPTION
This adds a TabSelectorPosition property to TabControl which allows you to specify if the tab buttons should be positioned on the top (default), right, bottom or left of the TabControl content.

The logic is implemented in the TabSelector setter. It can probably be improved on by somebody with a better understanding of how the Grid widget works, but in my tests it gets the job done.

I'll keep this PR updated if I discover any issues while using this control.