### PR TITLE
Handle UTF16 surrogate pairs in text boxes

### DIFF
--- a/src/Myra/Graphics2D/Text/TextChunk.cs
+++ b/src/Myra/Graphics2D/Text/TextChunk.cs
@@ -74,12 +74,22 @@ namespace Myra.Graphics2D.Text
 			var offset = Vector2.Zero;
 			for (var i = 0; i < _text.Length; ++i)
 			{
-				Vector2 v = _font.MeasureString(_text[i].ToString());
+				char c = _text[i];
+				
+				if (char.IsLowSurrogate(c))
+				{
+					// Hopefully the text is valid UTF16...
+					Glyphs[i].Bounds = Glyphs[i - 1].Bounds;
+					continue;	
+				}
+
+				Vector2 v = _font.MeasureString(char.IsHighSurrogate(c) ? _text.Substring(i, 2) : _text[i].ToString());
+
 				var result = new Rectangle((int)offset.X, (int)offset.Y, (int)v.X, (int)v.Y);
 
 				Glyphs[i].Bounds = result;
 
-				offset.X += v.X;
+				offset.X += v.X;	
 			}
 		}
 

--- a/src/Myra/Graphics2D/UI/TextBox.cs
+++ b/src/Myra/Graphics2D/UI/TextBox.cs
@@ -445,17 +445,32 @@ namespace Myra.Graphics2D.UI
 			}
 		}
 
-		private bool Delete(int where, int len)
+		private int Delete(int where, int len)
 		{
-			if (where < 0 || where >= Length || len < 0)
+			// If we're trying to delete one part
+			// of a surrogate pair, delete both.
+			if (len == 1)
 			{
-				return false;
+				if (char.IsSurrogate(Text[where]))
+				{
+					len++;
+				}
+
+				if (char.IsLowSurrogate(Text[where]))
+				{
+					where--;
+				}
 			}
 
+			if (where < 0 || where >= Length || len < 0)
+			{
+				return 0;
+			}
+			
 			UndoStack.MakeDelete(Text, where, len);
 			DeleteChars(where, len);
 
-			return true;
+			return len;
 		}
 
 		private void DeleteSelection()
@@ -778,9 +793,10 @@ namespace Myra.Graphics2D.UI
 					{
 						if (SelectStart == SelectEnd)
 						{
-							if (Delete(CursorPosition - 1, 1))
+							int deleted = Delete(CursorPosition - 1, 1);
+							if (deleted > 0)
 							{
-								UserSetCursorPosition(CursorPosition - 1);
+								UserSetCursorPosition(CursorPosition - deleted);
 								ResetSelection();
 							}
 						}

--- a/src/Myra/Graphics2D/UI/TextBox.cs
+++ b/src/Myra/Graphics2D/UI/TextBox.cs
@@ -447,6 +447,11 @@ namespace Myra.Graphics2D.UI
 
 		private int Delete(int where, int len)
 		{
+			if (where < 0 || where >= Length || len < 0)
+			{
+				return 0;
+			}
+			
 			// If we're trying to delete one part
 			// of a surrogate pair, delete both.
 			if (len == 1)
@@ -460,11 +465,6 @@ namespace Myra.Graphics2D.UI
 				{
 					where--;
 				}
-			}
-
-			if (where < 0 || where >= Length || len < 0)
-			{
-				return 0;
 			}
 			
 			UndoStack.MakeDelete(Text, where, len);


### PR DESCRIPTION
There's still some jank as a result of having one glyph per character, but Myra should no longer throw when displaying and editing textboxes containing (valid) surrogate pairs.