### PR TITLE
Fix memory leak

### DIFF
--- a/src/Myra/Graphics2D/RenderContext.cs
+++ b/src/Myra/Graphics2D/RenderContext.cs
@@ -1,3 +1,4 @@
+using System;
 using FontStashSharp;
 using Myra.Utility;
 using FontStashSharp.RichText;
@@ -26,7 +27,7 @@ namespace Myra.Graphics2D
 		Linear
 	}
 
-	public partial class RenderContext
+	public partial class RenderContext : IDisposable
 	{
 #if MONOGAME || FNA
 		private static RasterizerState _uiRasterizerState;
@@ -438,6 +439,24 @@ namespace Myra.Graphics2D
 
 			End();
 			Begin();
+		}
+
+		private void ReleaseUnmanagedResources()
+		{
+#if MONOGAME || FNA || STRIDE
+			_renderer?.Dispose();
+#endif
+		}
+
+		public void Dispose()
+		{
+			ReleaseUnmanagedResources();
+			GC.SuppressFinalize(this);
+		}
+
+		~RenderContext()
+		{
+			ReleaseUnmanagedResources();
 		}
 	}
 }

--- a/src/Myra/Graphics2D/UI/Desktop.cs
+++ b/src/Myra/Graphics2D/UI/Desktop.cs
@@ -30,7 +30,7 @@ namespace Myra.Graphics2D.UI
 		public float Wheel;
 	}
 
-	public class Desktop: ITransformable
+	public class Desktop: ITransformable, IDisposable
 	{
 		public const int DoubleClickIntervalInMs = 500;
 		public const int DoubleClickRadius = 2;
@@ -65,6 +65,8 @@ namespace Myra.Graphics2D.UI
 #if MONOGAME || PLATFORM_AGNOSTIC
 		public bool HasExternalTextInput = false;
 #endif
+
+		private bool _isDisposed = false;
 
 		/// <summary>
 		/// Root Widget
@@ -480,10 +482,7 @@ namespace Myra.Graphics2D.UI
 			KeyDownHandler = OnKeyDown;
 
 #if FNA
-			TextInputEXT.TextInput += c =>
-			{
-				OnChar(c);
-			};
+			TextInputEXT.TextInput += OnChar;
 #endif
 
 			if (Stylesheet.Current.DesktopStyle != null)
@@ -1293,6 +1292,29 @@ namespace Myra.Graphics2D.UI
 		{
 			var size = CrossEngineStuff.ViewSize;
 			return new Rectangle(0, 0, size.X, size.Y);
+		}
+
+		private void ReleaseUnmanagedResources()
+		{
+			_renderContext.Dispose();
+		}
+
+		public void Dispose()
+		{
+			if (_isDisposed)
+				return;
+
+#if FNA
+			TextInputEXT.TextInput -= OnChar;
+#endif
+
+			ReleaseUnmanagedResources();
+			GC.SuppressFinalize(this);
+		}
+
+		~Desktop()
+		{
+			ReleaseUnmanagedResources();
 		}
 	}
 }


### PR DESCRIPTION
As mentioned in Discord, `RenderContext` not disposing the underlying `SpriteBatch` was causing GPU resources to never be released. This PR implements that using the Dispose pattern so that it can be reclaimed even if not explicitly disposed

Also adds `TextInputEXT.TextInput -= OnChar;` to remove the permanent reference on the object so that it can eventually be cleaned up by the garbage collector