### PR TITLE
walkaround for Monogame Widgets Drawlines not from center origin.

### DIFF
--- a/src/Myra/Graphics2D/RenderContext.Shapes.cs
+++ b/src/Myra/Graphics2D/RenderContext.Shapes.cs
@@ -181,7 +181,7 @@ namespace Myra.Graphics2D
 			float thickness = 1f)
 		{
 			var scale = new Vector2(length, thickness);
-			Draw(DefaultAssets.WhiteTexture, point, null, color, angle, scale, 0);
+			Draw(DefaultAssets.WhiteTexture, point, null, color, angle, scale, 0, drawLine: true);
 		}
 
 		/// <summary>

--- a/src/Myra/Graphics2D/RenderContext.cs
+++ b/src/Myra/Graphics2D/RenderContext.cs
@@ -234,7 +234,7 @@ namespace Myra.Graphics2D
 		/// <param name="color"></param>
 		/// <param name="rotation"></param>
 		/// <param name="depth"></param>
-		public void Draw(Texture2D texture, Vector2 position, Rectangle? sourceRectangle, Color color, float rotation, Vector2 scale, float depth = 0.0f)
+		public void Draw(Texture2D texture, Vector2 position, Rectangle? sourceRectangle, Color color, float rotation, Vector2 scale, float depth = 0.0f, bool drawLine = false)
 		{
 			SetTextureFiltering(TextureFiltering.Nearest);
 			color = CrossEngineStuff.MultiplyColor(color, Opacity);
@@ -243,7 +243,8 @@ namespace Myra.Graphics2D
 
 #if MONOGAME || FNA
 			position = Transform.Apply(position);
-			 _renderer.Draw(texture, position, sourceRectangle, color, rotation, Vector2.Zero, scale, SpriteEffects.None, depth);
+			_renderer.Draw(texture, position, sourceRectangle, color, rotation,
+				drawLine ? new Vector2(0f, 0.5f) : Vector2.Zero, scale, SpriteEffects.None, depth);
 #elif STRIDE
 			position = Transform.Apply(position);
 			_renderer.Draw(texture, position, sourceRectangle, color, rotation, Vector2.Zero, scale, SpriteEffects.None, ImageOrientation.AsIs, depth);


### PR DESCRIPTION
simple walkaround aproach for the issues: #403