### PR TITLE
MonoGame(since 3.8.1) - Check if game window is active while triggering mouse click events

### DIFF
--- a/src/Myra/MyraEnvironment.cs
+++ b/src/Myra/MyraEnvironment.cs
@@ -292,9 +292,9 @@ namespace Myra
 			return new MouseInfo
 			{
 				Position = new Point(state.X, state.Y),
-				IsLeftButtonDown = state.LeftButton == ButtonState.Pressed,
-				IsMiddleButtonDown = state.MiddleButton == ButtonState.Pressed,
-				IsRightButtonDown = state.RightButton == ButtonState.Pressed,
+				IsLeftButtonDown = Game.IsActive && state.LeftButton == ButtonState.Pressed,
+				IsMiddleButtonDown = Game.IsActive && state.MiddleButton == ButtonState.Pressed,
+				IsRightButtonDown = Game.IsActive && state.RightButton == ButtonState.Pressed,
 				Wheel = state.ScrollWheelValue
 			};
 #elif STRIDE


### PR DESCRIPTION
After upgrade to MonoGame 3.8.1 I noticed that mouse events work while window is inactive. Apparently that is [intended behavior](https://github.com/MonoGame/MonoGame/issues/6428#issuecomment-421240327) and we have to additionally check `Game.IsActive`.