### PR TITLE
Update stride and .NET versions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,6 @@
     <InfoLundinMathVersion>1.2.6</InfoLundinMathVersion>
     <MonoGameVersion>3.8.0.1641</MonoGameVersion>
     <AppMonoGameVersion>3.8.1.303</AppMonoGameVersion>
-    <StrideVersion>4.1.0.1728</StrideVersion>
+    <StrideVersion>4.2.0.2067</StrideVersion>
   </PropertyGroup>
 </Project>

--- a/samples/Myra.Samples.AllWidgets/Myra.Samples.AllWidgets.Stride.csproj
+++ b/samples/Myra.Samples.AllWidgets/Myra.Samples.AllWidgets.Stride.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputPath>bin\Stride\$(Configuration)</OutputPath>
     <DefineConstants>$(DefineConstants);STRIDE</DefineConstants>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Stride.Engine" Version="4.1.0.1948" />
+    <PackageReference Include="Stride.Engine" Version="4.2.0.2067" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Myra/Myra.Stride.csproj
+++ b/src/Myra/Myra.Stride.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);STRIDE</DefineConstants>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageId>Myra.Stride</PackageId>
     <AssemblyName>Myra</AssemblyName>
     <OutputPath>bin\Stride\$(Configuration)</OutputPath>


### PR DESCRIPTION
updated to .NET 8 and Stride 4.2.

Question, would it be better to use `4.2.0.*` to always update minor versions when a Myra package is created?