### PR TITLE
Fixed bug for clas Studio and class TextBox

### DIFF
--- a/src/Myra/Events/TextDeletedEventArgs.cs
+++ b/src/Myra/Events/TextDeletedEventArgs.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace Myra.Events
+{
+    public class TextDeletedEventArgs : EventArgs
+    {
+        public int StartPosition
+        {
+            get;
+        }
+
+        public string Value
+        {
+            get;
+        }
+        
+        public TextDeletedEventArgs(int startPosition, string value)
+        {
+            StartPosition = startPosition;
+            Value = value;
+        }
+    }
+}

--- a/src/MyraPad/StringExtensions.cs
+++ b/src/MyraPad/StringExtensions.cs
@@ -1,0 +1,54 @@
+﻿namespace MyraPad
+{
+    internal static class StringExtensions
+    {
+        /// <summary>
+        /// Returns the character at the index of string, or returns null when out of range and does not throw exception.
+        /// </summary>
+        /// <param name="this"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        internal static char? GetCharSafely(this string @this, int index)
+        {
+            if (index < @this.Length && index >= 0)
+            {
+                return @this[index];
+            }
+
+            return null;
+        }
+        
+        /// <summary>
+        /// Returns a substring of this string, or returns null when out of range and does not throw exception.
+        /// </summary>
+        /// <param name="this"></param>
+        /// <param name="index"></param>
+        /// <param name="count"></param>
+        /// <returns></returns>
+        internal static string SubstringSafely(this string @this, int index, int count)
+        {
+            if (count <= 0)
+            {
+                return string.Empty;
+            }
+
+            if (index < 0)
+            {
+                return null;
+            }
+
+            if (index >= @this.Length)
+            {
+                return null;
+            }
+
+            if (index + count >= @this.Length)
+            {
+                return null;
+            }
+
+            return @this.Substring(index, count);
+
+        }
+    }
+}

--- a/src/MyraPad/StringExtensions.cs
+++ b/src/MyraPad/StringExtensions.cs
@@ -50,5 +50,25 @@
             return @this.Substring(index, count);
 
         }
+
+        public static int LastIndexOfSafely(this string @this, char character, int index)
+        {
+            if (index < 0 || index >= @this.Length)
+            {
+                return -1;
+            }
+
+            return @this.LastIndexOf(character, index);
+        }
+        
+        public static int IndexOfSafely(this string @this, char character, int index)
+        {
+            if (index < 0 || index >= @this.Length)
+            {
+                return -1;
+            }
+
+            return @this.IndexOf(character, index);
+        }
     }
 }

--- a/src/MyraPad/Studio.cs
+++ b/src/MyraPad/Studio.cs
@@ -502,16 +502,15 @@ namespace MyraPad
 			UpdateMenuFile();
 		}
 
-		private void _textSource_TextDeleted(object sender, TextDeletedEventArgs e)
+		private void _textSource_TextDeleted(object _, TextDeletedEventArgs e)
 		{
 			if (e.Value.Contains('\n'))
 			{
 				return;
 			}
 			
-			var endIndexOfLine = _ui._textSource.Text.IndexOf('\n', e.StartPosition);
-			var startIndexOfLine = _ui._textSource.Text.LastIndexOf('\n', e.StartPosition - 1);
-
+			int startIndexOfLine = _ui._textSource.Text.LastIndexOfSafely('\n', _ui._textSource.CursorPosition - 2);
+			var endIndexOfLine = _ui._textSource.Text.IndexOfSafely('\n', _ui._textSource.CursorPosition - 2);
 			if (endIndexOfLine < 0)
 			{
 				endIndexOfLine = _ui._textSource.Text.Length;

--- a/src/MyraPad/Studio.cs
+++ b/src/MyraPad/Studio.cs
@@ -483,7 +483,7 @@ namespace MyraPad
 			_ui._textSource.TextChanged += _textSource_TextChanged;
 			_ui._textSource.KeyDown += _textSource_KeyDown;
 			_ui._textSource.Char += _textSource_Char;
-
+			_ui._textSource.TextDeleted += _textSource_TextDeleted;
 			_ui._textStatus.Text = string.Empty;
 			_ui._textLocation.Text = "Line: 0, Column: 0, Indent: 0";
 
@@ -500,6 +500,39 @@ namespace MyraPad
 			_desktop.Root = _ui;
 
 			UpdateMenuFile();
+		}
+
+		private void _textSource_TextDeleted(object sender, TextDeletedEventArgs e)
+		{
+			if (e.Value.Contains('\n'))
+			{
+				return;
+			}
+			
+			var endIndexOfLine = _ui._textSource.Text.IndexOf('\n', e.StartPosition);
+			var startIndexOfLine = _ui._textSource.Text.LastIndexOf('\n', e.StartPosition - 1);
+
+			if (endIndexOfLine < 0)
+			{
+				endIndexOfLine = _ui._textSource.Text.Length;
+			}
+			
+			if (startIndexOfLine < 0)
+			{
+				startIndexOfLine = 0;
+			}
+			
+			var currentLineString = _ui._textSource.Text[startIndexOfLine..endIndexOfLine];
+			if (currentLineString is null)
+			{
+				return;
+			}
+			
+			if (string.IsNullOrWhiteSpace(currentLineString))
+			{
+				_ui._textSource.Text = _ui._textSource.Text.Remove(startIndexOfLine, currentLineString.Length);
+				_ui._textSource.CursorPosition = startIndexOfLine + 1;
+			}
 		}
 
 		private void _textBoxFilter_TextChanged(object sender, ValueChangedEventArgs<string> e)
@@ -742,20 +775,24 @@ namespace MyraPad
 				return;
 			}
 
-			var il = _indentLevel;
-			if (pos < text.Length - 2 && text[pos] == '<' && text[pos + 1] == '/')
-			{
-				--il;
-			}
+			var indentLevel = _indentLevel;
+			bool wrapAfterIndent = text.SubstringSafely(pos + 1, 2) == "</";
 
-			if (il <= 0)
+			if (indentLevel <= 0)
 			{
 				return;
 			}
 
 			// Insert indent
-			var indent = new string(' ', il * _options.IndentSpacesSize);
-			_ui._textSource.Insert(pos, indent);
+			var indent = new string(' ', indentLevel * _options.IndentSpacesSize);
+			if (wrapAfterIndent)
+			{
+				indent += '\n';
+			}
+			_ui._textSource.Insert(pos + 1, indent);
+
+			_ui._textSource.CursorPosition = pos + 2;
+			//Move the cursor to the position after indent
 		}
 
 		private void ApplyAutoClose()
@@ -768,15 +805,18 @@ namespace MyraPad
 			_applyAutoClose = false;
 
 			var pos = _ui._textSource.CursorPosition;
-
 			var currentTag = CurrentTag;
 			if (string.IsNullOrEmpty(currentTag) || !_needsCloseTag)
 			{
 				return;
 			}
 
-			var close = "</" + ExtractTag(currentTag) + ">";
-			_ui._textSource.Insert(pos, close);
+			var closeTag = "</" + ExtractTag(currentTag) + ">";
+			_ui._textSource.Insert(pos + 1, closeTag);
+			
+			_ui._textSource.CursorPosition = pos;
+			//Method Insert(int, string) has moved the cursor position
+			//this will restore the cursor to the position after '<Tag>' and before '<Tag/>'
 		}
 
 		private void _textSource_TextChanged(object sender, ValueChangedEventArgs<string> e)


### PR DESCRIPTION
For class TextBox in project Myra:
  Now cursor won't refresh while user is typing
For class Studio in project MyraPad:
  Fixed bug that when you Type '<' after a Xml tag such as '<Panel', the code editor will Insert '</Panel>' before '>' but not after '>'
  Before: '<Panel</Panel>>'
  Now: '<Panel></Panel>'
  But there are still several bugs in Studio.cs, like: auto indent don't works correctly.
Added class StringExtensions.