### PR TITLE
PropertyGrid Bug Fix: when an enum is changed, PropertyChanged EventArgs returns the enum type, which should be the enum variable name.

### DIFF
--- a/src/Myra/Graphics2D/UI/Properties/PropertyGrid.cs
+++ b/src/Myra/Graphics2D/UI/Properties/PropertyGrid.cs
@@ -687,7 +687,7 @@ namespace Myra.Graphics2D.UI.Properties
 					if (cv.SelectedIndex != -1)
 					{
 						SetValue(record, _object, cv.SelectedItem.Tag);
-						FireChanged(enumType.Name);
+						FireChanged(record.Name);
 					}
 				};
 			}


### PR DESCRIPTION
For example,
``` CSharp
public enum Fruit
{
    Apple,
    Orange,
}

public Fruit Selected1 { get; set; } 
public Fruit Selected2 { get; set; } 

private void PropertyGrid_PropertyChanged(object sender, GenericEventArgs<string> e)
{
    Debug.WriteLine(e.Data); // the output is "Fruit", however it should be "Selected1", "Selected2", ...
}
```

At `PropertyGrid.cs` line 690, I changed `FireChanged(enumType.Name)` to `FireChanged(record.Name)`. And then it worked well!
