### PR TITLE
Optional anisotropic filtering added to component "Image"

### DIFF
--- a/src/Myra/Graphics2D/UI/Containers/ScrollViewer.cs
+++ b/src/Myra/Graphics2D/UI/Containers/ScrollViewer.cs
@@ -135,7 +135,13 @@ namespace Myra.Graphics2D.UI
 			get; set;
 		}
 
-		[Browsable(false)]
+		[Category("Appearance")]
+		public int ScrollMultiplier
+		{
+			get; set;
+		} = 10;
+
+        [Browsable(false)]
 		[Content]
 		public override Widget Content
 		{
@@ -395,7 +401,7 @@ namespace Myra.Graphics2D.UI
 				return;
 			}
 
-			var step = 10 * ScrollMaximum.Y / _thumbMaximumY;
+			var step = ScrollMultiplier * ScrollMaximum.Y / _thumbMaximumY;
 			if (delta < 0)
 			{
 				_scrollbarOrientation = Orientation.Vertical;

--- a/src/Myra/Graphics2D/UI/Simple/Image.cs
+++ b/src/Myra/Graphics2D/UI/Simple/Image.cs
@@ -35,7 +35,22 @@ namespace Myra.Graphics2D.UI
 	{
 		private IImage _image, _overImage, _pressedImage;
 
-		[Category("Appearance")]
+        private bool _isAnisotropicFiltering = false;
+
+        public bool IsAnisotropicFiltering
+        {
+            get
+            {
+                return _isAnisotropicFiltering;
+            }
+            set
+            {
+                _isAnisotropicFiltering = value;
+                InvalidateMeasure();
+            }
+        }
+
+        [Category("Appearance")]
 		public IImage Renderable
 		{
 			get
@@ -164,8 +179,10 @@ namespace Myra.Graphics2D.UI
 					bounds.Height = (int)(bounds.Width * aspect);
 				}
 
-				image.Draw(context, bounds, Color);
-			}
+                context.SetAnisotropicFilteringMode(_isAnisotropicFiltering);
+                image.Draw(context, bounds, Color);
+                context.SetAnisotropicFilteringMode(false);
+            }
 		}
 
 		public void ApplyPressableImageStyle(PressableImageStyle imageStyle)


### PR DESCRIPTION
Add optional texture filtering for component "Image". It necessary for scale down images, for example - before and after

![compare](https://github.com/user-attachments/assets/bd977678-f3e9-47ce-8ba1-ffc2bfccb09d)