### PR TITLE
Close key on window now can setted to null - needed for turning off closing by key

### DIFF
--- a/src/Myra/Graphics2D/UI/Misc/Window.cs
+++ b/src/Myra/Graphics2D/UI/Misc/Window.cs
@@ -144,7 +144,7 @@ namespace Myra.Graphics2D.UI
 
 		[Category("Behavior")]
 		[DefaultValue(Keys.Escape)]
-		public Keys CloseKey { get; set; }
+		public Keys? CloseKey { get; set; }
 
 		private bool IsWindowPlaced { get; set; }
 


### PR DESCRIPTION
Close key on window now can be set to null - it needed for turning off closing by key. For example if I want the user not to be able to accidentally close the window