### PR TITLE
MyraPad fix for startup crash on linux systems. (URIFormatException)

### DIFF
--- a/samples/Myra.Samples.AssetManagement/PathUtils.cs
+++ b/samples/Myra.Samples.AssetManagement/PathUtils.cs
@@ -11,7 +11,7 @@ namespace Myra.Samples.AssetManagement
 			get
 			{
 				string codeBase = Assembly.GetExecutingAssembly().Location;
-				UriBuilder uri = new UriBuilder(codeBase);
+				UriBuilder uri = new UriBuilder($"path:{codeBase}");
 				string path = Uri.UnescapeDataString(uri.Path);
 				return Path.GetDirectoryName(path);
 			}

--- a/src/Myra/Utility/PathUtils.cs
+++ b/src/Myra/Utility/PathUtils.cs
@@ -11,7 +11,7 @@ namespace Myra.Utility
 			get
 			{
 				string codeBase = Assembly.GetExecutingAssembly().Location;
-				UriBuilder uri = new UriBuilder(codeBase);
+				UriBuilder uri = new UriBuilder($"path:{codeBase}");
 				string path = Uri.UnescapeDataString(uri.Path);
 				return Path.GetDirectoryName(path);
 			}


### PR DESCRIPTION
(_Somehow, this is my first ever PR_)

Implements the fix mentioned in issue #483 

This change fixes a MyraPad crash on Linux (possibly Mac) caused when trying to create a string using URIBuilder, resulting in an URIFormatException. 
It simply prepends `path:` so the system treats the string as a file/directory rather than an invalid URL. (because file directories start with `/` on unix systems)

Untested on Windows, but it should still work there.