### PR TITLE
Improved FileDialog Side-Panel + OS compatibility

### DIFF
--- a/src/Myra/Graphics2D/UI/File/FileDialog.PlatformDependent.cs
+++ b/src/Myra/Graphics2D/UI/File/FileDialog.PlatformDependent.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using MonoGame.Utilities;
+
+namespace Myra.Graphics2D.UI.File
+{
+    // === Platform dependent code for FileDialog class
+    public partial class FileDialog
+    {
+        private static class Platform
+        {
+            public static void InitListedSystemDrives(IList<Widget> widgets)
+            {
+                switch (CurrentPlatform.OS)
+                {
+                    case OS.Windows:
+                        InitSysDrivesWindows(widgets);
+                        return;
+                    case OS.MacOSX:
+                        //TODO mac specific - using old windows code for now!
+                        InitSysDrivesWindows(widgets);
+                        return;
+                    case OS.Linux:
+                        InitSysDrivesLinux(widgets);
+                        return;
+                }
+            }
+
+#region Windows
+            private static void InitSysDrivesWindows(IList<Widget> widgets)
+            {
+                var drives = GetWindowsDevices();
+                foreach (var d in drives)
+                {
+                    try
+                    {
+                        var s = d.RootDirectory.FullName;
+
+                        if (!string.IsNullOrEmpty(d.VolumeLabel) && d.VolumeLabel != d.RootDirectory.FullName) //VolumeLabel is only supported on win
+                        {
+                            s += " (" + d.VolumeLabel + ")";
+                        }
+
+                        var item = CreateListItem(s, d.RootDirectory.FullName, true);
+                        widgets.Add(item);
+                    }
+                    catch (Exception)
+                    {
+                    }
+                }
+            }
+            private static List<DriveInfo> GetWindowsDevices()
+            {
+                bool TestDriveType(DriveType type)
+                {
+                    switch (type)
+                    {
+                        case DriveType.CDRom:
+                        case DriveType.Fixed:
+                        case DriveType.Network:
+                        case DriveType.Removable:
+                            return true;
+                        case DriveType.NoRootDirectory:
+                        case DriveType.Unknown:
+                        case DriveType.Ram:
+                        default:
+                            return false;
+                    }
+                }
+                
+                List<DriveInfo> result = new List<DriveInfo>(8);
+                foreach (var drive in DriveInfo.GetDrives())
+                {
+                    if(TestDriveType(drive.DriveType))
+                        result.Add(drive);
+                }
+                return result;
+            }
+#endregion Windows
+#region Linux
+            private static void InitSysDrivesLinux(IList<Widget> widgets)
+            {
+                // Use bash 'lsblk' to collect device info
+                var drives = GetLinuxDevices();
+                
+                foreach (var d in drives)
+                {
+                    widgets.Add(CreateListItem($"({d.VolumeLabel}) {d.Label}", d.Path, true));
+                }
+            }
+
+            private static List<DeviceInfo> GetLinuxDevices()
+            {
+                const string RawSpace = @"\x20";
+                string tmpFileName = Path.GetTempFileName();
+                string[] bashResult;
+                try
+                {
+                    BashRunner.Run($"lsblk -n -o TYPE,NAME,LABEL,MOUNTPOINT --raw > {tmpFileName}"); //MODE,
+                    bashResult = System.IO.File.ReadAllLines(tmpFileName);
+                }
+                finally
+                {
+                    System.IO.File.Delete(tmpFileName);
+                }
+                
+                List<DeviceInfo> result = new List<DeviceInfo>(8);
+                foreach (string deviceLine in bashResult)
+                {
+                    string[] splits = deviceLine.Split(new[] { ' ' }, StringSplitOptions.None);
+                    
+                    if(splits[0] != "part") //TYPE
+                        continue; // We only want partitioned for file systems.
+
+                    splits[2] = splits[2].Replace(RawSpace, " ");
+                    if(string.Equals(splits[2], "System Reserved")) //LABEL
+                        continue;
+                    
+                    if(string.IsNullOrEmpty(splits[3]) || string.Equals(splits[3], "/boot"))
+                        continue;
+                    splits[3] = splits[3].Replace(RawSpace, " ");; //MOUNTPOINT
+                    
+                    result.Add(new DeviceInfo(splits[1], splits[2], splits[3]));
+                }
+                return result;
+            }
+#endregion Linux
+            private class DeviceInfo
+            {
+                public DeviceInfo(string volume, string label, string path)
+                {
+                    VolumeLabel = volume;
+                    Label = label;
+                    Path = path;
+                }
+
+                public readonly string VolumeLabel;
+                public readonly string Label;
+                public readonly string Path;
+            }
+        }
+
+    }
+}

--- a/src/Myra/Graphics2D/UI/File/FileDialog.cs
+++ b/src/Myra/Graphics2D/UI/File/FileDialog.cs
@@ -8,7 +8,7 @@ namespace Myra.Graphics2D.UI.File
 {
 	public partial class FileDialog
 	{
-		private class PathInfo
+		protected class PathInfo
 		{
 			public string Path { get; }
 			public bool IsDrive { get; }
@@ -19,14 +19,33 @@ namespace Myra.Graphics2D.UI.File
 				IsDrive = isDrive;
 			}
 		}
+		/// <summary>
+		/// Container for info about a browsable file system or device.
+		/// </summary>
+		protected class Location
+		{
+			public Location(string volume, string label, string path, bool isDrive)
+			{
+				VolumeLabel = volume;
+				Label = label;
+				Path = path;
+				IsDrive = isDrive;
+			}
+            
+			public readonly string VolumeLabel;
+			public readonly string Label;
+			public readonly string Path;
+			public readonly bool IsDrive;
+			
+			public bool TryAccess() => TryAccess(this.Path);
+			public static bool TryAccess(string path)
+			{
+				throw new NotImplementedException();
+			}
+		}
 
 		private const int ImageTextSpacing = 4;
-
-		private static readonly string[] Folders =
-		{
-			"Desktop", "Downloads"
-		};
-
+		
 		private readonly List<string> _paths = new List<string>();
 		private readonly List<string> _history = new List<string>();
 		private int _historyPosition;
@@ -134,50 +153,16 @@ namespace Myra.Graphics2D.UI.File
 			_buttonBack.Background = null;
 			_buttonForward.Background = null;
 			_buttonParent.Background = null;
+			_listPlaces.Background = null; 
+			
+			PopulatePlacesListUI(_listPlaces);
 
-			_listPlaces.Background = null;
-
-			var homePath = (Environment.OSVersion.Platform == PlatformID.Unix ||
-							Environment.OSVersion.Platform == PlatformID.MacOSX)
-				? Environment.GetEnvironmentVariable("HOME")
-				: Environment.ExpandEnvironmentVariables("%HOMEDRIVE%%HOMEPATH%");
-
-			var places = new List<string>
-			{
-				homePath
-			};
-
-			foreach (var f in Folders)
-			{
-				places.Add(Path.Combine(homePath, f));
-			}
-
-			foreach (var p in places)
-			{
-				if (!Directory.Exists(p))
-				{
-					continue;
-				}
-
-				var item = CreateListItem(Path.GetFileName(p), p, false);
-				_listPlaces.Widgets.Add(item);
-			}
-
-			if (_listPlaces.Widgets.Count > 0)
+			if (_listPlaces.Widgets.Count > 0) //Set starting folder
 			{
 				var pathInfo = (PathInfo)_listPlaces.Widgets[0].Tag;
 				SetFolder(pathInfo.Path, false);
 			}
-
-			_listPlaces.Widgets.Add(new HorizontalSeparator());
-			foreach (DeviceInfo drive in Platform.GetDrivesOnSystem()) //Add file system drives
-			{
-				string label = string.IsNullOrEmpty(drive.VolumeLabel) ? 
-					drive.Label :
-					$"{drive.Label} ({drive.VolumeLabel})";
-				_listPlaces.Widgets.Add( CreateListItem(label, drive.Path, true) );
-			}
-
+			
 			_listPlaces.SelectedIndexChanged += OnPlacesSelectedIndexChanged;
 
 			_gridFiles.SelectedIndexChanged += OnGridFilesSelectedIndexChanged;
@@ -197,20 +182,42 @@ namespace Myra.Graphics2D.UI.File
 			SetStyle(Stylesheet.DefaultStyleName);
 		}
 
-		private static Widget CreateListItem(string text, string path, bool isDrive)
+		protected virtual void PopulatePlacesListUI(ListView listView)
+		{
+			List<Location> placeList = new List<Location>(8);
+			int index = 0;
+			
+			//Add user directories
+			Platform.AppendUserPlacesOnSystem(placeList, Platform.SystemUserPlacePaths);
+			for (; index < placeList.Count; index++)
+				listView.Widgets.Add( CreateListItem(placeList[index]) );
+			
+			if (_listPlaces.Widgets.Count > 0)
+				listView.Widgets.Add(new HorizontalSeparator());
+			
+			//Add file system drives
+			Platform.AppendDrivesOnSystem(placeList);
+			for (; index < placeList.Count; index++)
+				listView.Widgets.Add( CreateListItem(placeList[index]) );
+		}
+		
+		protected virtual Widget CreateListItem(Location location)
 		{
 			var item = new HorizontalStackPanel
 			{
 				Spacing = ImageTextSpacing,
-				Tag = new PathInfo(path, isDrive)
+				Tag = new PathInfo(location.Path, location.IsDrive)
 			};
 
+			string label = string.IsNullOrEmpty(location.VolumeLabel) 
+				? location.Label 
+				: $"[{location.VolumeLabel}] {location.Label}";
+			
 			item.Widgets.Add(new Image());
-			item.Widgets.Add(new Label { Text = text });
-
+			item.Widgets.Add(new Label { Text = label });
 			return item;
 		}
-
+		
 		private void UpdateEnabled()
 		{
 			var enabled = false;

--- a/src/Myra/Graphics2D/UI/File/FileDialog.cs
+++ b/src/Myra/Graphics2D/UI/File/FileDialog.cs
@@ -171,30 +171,7 @@ namespace Myra.Graphics2D.UI.File
 
 			_listPlaces.Widgets.Add(new HorizontalSeparator());
 
-			var drives = DriveInfo.GetDrives();
-			foreach (var d in drives)
-			{
-				if (d.DriveType == DriveType.Ram || d.DriveType == DriveType.Unknown)
-				{
-					continue;
-				}
-
-				try
-				{
-					var s = d.RootDirectory.FullName;
-
-					if (!string.IsNullOrEmpty(d.VolumeLabel) && d.VolumeLabel != d.RootDirectory.FullName)
-					{
-						s += " (" + d.VolumeLabel + ")";
-					}
-
-					var item = CreateListItem(s, d.RootDirectory.FullName, true);
-					_listPlaces.Widgets.Add(item);
-				}
-				catch (Exception)
-				{
-				}
-			}
+			Platform.InitListedSystemDrives(_listPlaces.Widgets);
 
 			_listPlaces.SelectedIndexChanged += OnPlacesSelectedIndexChanged;
 

--- a/src/Myra/Graphics2D/UI/File/FileDialog.cs
+++ b/src/Myra/Graphics2D/UI/File/FileDialog.cs
@@ -170,8 +170,13 @@ namespace Myra.Graphics2D.UI.File
 			}
 
 			_listPlaces.Widgets.Add(new HorizontalSeparator());
-
-			Platform.InitListedSystemDrives(_listPlaces.Widgets);
+			foreach (DeviceInfo drive in Platform.GetDrivesOnSystem()) //Add file system drives
+			{
+				string label = string.IsNullOrEmpty(drive.VolumeLabel) ? 
+					drive.Label :
+					$"{drive.Label} ({drive.VolumeLabel})";
+				_listPlaces.Widgets.Add( CreateListItem(label, drive.Path, true) );
+			}
 
 			_listPlaces.SelectedIndexChanged += OnPlacesSelectedIndexChanged;
 

--- a/src/Myra/Myra.MonoGame.csproj
+++ b/src/Myra/Myra.MonoGame.csproj
@@ -17,6 +17,9 @@
 
   <ItemGroup>
     <Compile Remove="Platform\**\*.*" />
+    <Compile Update="Graphics2D\UI\File\FileDialog.PlatformDependent.cs">
+      <DependentUpon>FileDialog.cs</DependentUpon>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR improves the FileDialog class:

Restructured the way "place" and "drive" directories are queried from the system, to be OS independent:
- On Linux, drives are queried from the system using bash `lsblk` command.
- Mac is still using the old (windows) way of "places/drives" - _**I did not add Mac/OSX support.**_
- "Places" under the user's HOME folder are now adjustable per-OS. (Not configurable)
- Added user Documents, Pictures directories.
- Added support to override the "places/drives" widget-list creation at a few different points.

Crashing will still occur if you navigate to a directory the app doesn't have permissions for.
_This is untested on anything other than my Linux system._