### PR TITLE
FileDialog Improvements: Crash Fix, File Filtering, Permission Checking

### DIFF
--- a/src/Myra/Graphics2D/UI/File/FileDialog.PlatformDependent.cs
+++ b/src/Myra/Graphics2D/UI/File/FileDialog.PlatformDependent.cs
@@ -96,11 +96,8 @@ namespace Myra.Graphics2D.UI.File
                 
                 foreach (string path in places)
                 {
-                    if (!Directory.Exists(path))
+                    if (!TryGetFileAttributes(path, out _))
                         continue;
-				    
-                    //TODO check permissions for those places here
-                    //Location.TryAccess(path);
                     
                     appendResult.Add(new Location(string.Empty, Path.GetFileName(path), path, false ));
                 }
@@ -191,13 +188,22 @@ namespace Myra.Graphics2D.UI.File
                     if(splits[0] != "part") //TYPE
                         continue; // We only want partitioned file systems.
 
-                    splits[2] = splits[2].Replace(RawSpace, " ");
-                    if(string.Equals(splits[2], "System Reserved")) //LABEL
+                    splits[2] = splits[2].Replace(RawSpace, " "); //LABEL
+                    if(string.Equals(splits[2], "System Reserved")) 
                         continue;
+                    if (string.IsNullOrEmpty(splits[2]))
+                    {
+                        //Is this the main system partition?
+                        if (string.Equals(splits[3], "/home") || string.Equals(splits[3], "/"))
+                        {
+                            appendResult.Add(new Location(splits[1], "Linux System", "/", true));
+                            continue;
+                        }
+                    }
                     
                     if(string.IsNullOrEmpty(splits[3]) || string.Equals(splits[3], "/boot"))
                         continue;
-                    splits[3] = splits[3].Replace(RawSpace, " ");; //MOUNTPOINT
+                    splits[3] = splits[3].Replace(RawSpace, " "); //MOUNTPOINT
                     
                     appendResult.Add(new Location(splits[1], splits[2], splits[3], true));
                 }

--- a/src/Myra/Graphics2D/UI/File/FileDialog.Util.cs
+++ b/src/Myra/Graphics2D/UI/File/FileDialog.Util.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Myra.Graphics2D.UI.File
+{
+    // === Static file IO utility methods
+    public partial class FileDialog
+    {
+        /// <summary>
+        /// Attempt to retrieve folders from the given directory <paramref name="path"/>. Result <paramref name="folders"/> is null if return value is false.
+        /// </summary>
+        protected static bool TryEnumerateDirectoryFolders(string path, out IEnumerable<string> folders, out string exceptionMsg)
+        {
+            List<string> result = new List<string>(8);
+            try
+            {
+                result.AddRange(Directory.EnumerateDirectories(path));
+            }
+            catch (Exception e)
+            {
+                exceptionMsg = e.Message;
+                folders = null;
+                return false;
+            }
+            result.Sort();
+            folders = result;
+            exceptionMsg = null;
+            return true;
+        }
+        
+        /// <summary>
+        /// Attempt to retrieve files from the given directory <paramref name="path"/>. Result <paramref name="files"/> is null if return value is false.
+        /// <paramref name="searchPattern"/> can be null for a wildcard.
+        /// </summary>
+        protected static bool TryEnumerateDirectoryFiles(string path, string searchPattern, out IEnumerable<string> files, out string exceptionMsg)
+        {
+            List<string> result = new List<string>(8);
+            try
+            {
+                if (string.IsNullOrEmpty(searchPattern))
+                    result.AddRange(Directory.EnumerateFiles(path));
+                else
+                {
+                    foreach (string pattern in searchPattern.Split(new char[]{ '|' }, StringSplitOptions.RemoveEmptyEntries))
+                        result.AddRange(Directory.EnumerateFiles(path, pattern));
+                }
+            }
+            catch (Exception e)
+            {
+                exceptionMsg = e.Message;
+                files = null;
+                return false;
+            }
+            result.Sort();
+            files = result;
+            exceptionMsg = null;
+            return true;
+        }
+
+        /// <summary>
+        /// Attempt to retreive permissions about a file or directory. Return value is indicative of success and a basic attribute filter.
+        /// </summary>
+        protected static bool TryGetFileAttributes(string path, out FileAttributes attributes)
+        {
+            try
+            {
+                attributes = new FileInfo(path).Attributes;
+            }
+            catch
+            {
+                attributes = 0;
+                return false;
+            }
+
+            bool discard =
+                attributes.HasFlag(FileAttributes.System) |
+                attributes.HasFlag(FileAttributes.Offline);
+            
+            return !discard;
+        }
+    }
+}

--- a/src/Myra/Myra.MonoGame.csproj
+++ b/src/Myra/Myra.MonoGame.csproj
@@ -20,6 +20,9 @@
     <Compile Update="Graphics2D\UI\File\FileDialog.PlatformDependent.cs">
       <DependentUpon>FileDialog.cs</DependentUpon>
     </Compile>
+    <Compile Update="Graphics2D\UI\File\FileDialog.Util.cs">
+      <DependentUpon>FileDialog.cs</DependentUpon>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Another PR to improve FileDialog:

- Fixes issues #443 #492
- Adds a file/folder filtering system based on FileAttributes enum.
- Files and Folders will now not display _at all_ if the app (or class settings) does not have permissions to interact with them. Even if you DID (like by overriding) it will now show a popup with a basic message about the IO exception. (popup untested)
- Read-only files are filtered out in "SaveFile" mode.
- Non-directory "files" are filtered out in "ChooseFolder" mode. (technically, redundant with prior code)
- Added ability to show system-hidden files and folders via public variable (default off).
- Files and folders are now sorted alphabetically instead of randomly by the runtime.
- Linux: Added a missing label for the primary OS partition, and it now explicitly directs to `/` instead of `/home`, or another mounted directory.
