### PR TITLE
* support for ViewportAdapter and Matrix scale for Myra/XNA

### DIFF
--- a/src/Myra/Graphics2D/MyraViewportAdapter.cs
+++ b/src/Myra/Graphics2D/MyraViewportAdapter.cs
@@ -1,0 +1,25 @@
+﻿#if MONOGAME || FNA
+using Microsoft.Xna.Framework;
+#elif STRIDE
+using Stride.Core.Mathematics;
+#else
+using System.Drawing;
+using System.Numerics;
+using Matrix = System.Numerics.Matrix3x2;
+#endif
+
+namespace Myra.Graphics2D
+{
+    public struct MyraViewportAdapter
+    {
+        public int VirtualWidth { get; set; }
+
+        public int VirtualHeight { get; set; }
+
+        public int X { get; set; }
+
+        public int Y { get; set; }
+
+        public Matrix TransformMatrix { get; set; }
+    }
+}

--- a/src/Myra/Graphics2D/RenderContext.cs
+++ b/src/Myra/Graphics2D/RenderContext.cs
@@ -98,9 +98,11 @@ namespace Myra.Graphics2D
 		private bool _beginCalled;
 		private Rectangle _scissor;
 		private TextureFiltering _textureFiltering = TextureFiltering.Nearest;
-		public Transform Transform;
+		public Transform Transform; 
+		public Matrix? TransformMatrix { get; set; }
+
 #if MONOGAME
-		private bool _isAnisotropicFilteringOn;
+        private bool _isAnisotropicFilteringOn;
 #endif
 
 		internal Rectangle DeviceScissor
@@ -466,7 +468,8 @@ namespace Myra.Graphics2D
 				samplerState,
 				null,
 				UIRasterizerState,
-				null);
+				null,
+                TransformMatrix);
 #elif STRIDE
 			var samplerState = SelectedSamplerState();
 
@@ -480,7 +483,7 @@ namespace Myra.Graphics2D
 			_renderer.Begin(_textureFiltering);
 #endif
 
-			_beginCalled = true;
+            _beginCalled = true;
 		}
 
 #if MONOGAME || FNA

--- a/src/Myra/Graphics2D/RenderContext.cs
+++ b/src/Myra/Graphics2D/RenderContext.cs
@@ -20,6 +20,10 @@ using Texture2D = System.Object;
 using Color = FontStashSharp.FSColor;
 #endif
 
+#if PLATFORM_AGNOSTIC
+using Matrix = System.Numerics.Matrix3x2;
+#endif
+
 namespace Myra.Graphics2D
 {
 	public enum TextureFiltering

--- a/src/Myra/Graphics2D/Transform.cs
+++ b/src/Myra/Graphics2D/Transform.cs
@@ -20,7 +20,15 @@ namespace Myra.Graphics2D
 
 		public Matrix Matrix;
 
-		public Transform(Vector2 offset, Vector2 origin, Vector2 scale, float rotation)
+        public Transform(Matrix newMatrix, Vector2 scale, float rotation)
+        {
+            Matrix = newMatrix;
+
+            Scale = scale;
+            Rotation = rotation;
+        }
+
+        public Transform(Vector2 offset, Vector2 origin, Vector2 scale, float rotation)
 		{
 			Matrix newMatrix;
 			BuildTransform(offset, origin, scale, rotation, out newMatrix);

--- a/src/Myra/Graphics2D/UI/Desktop.Input.cs
+++ b/src/Myra/Graphics2D/UI/Desktop.Input.cs
@@ -148,7 +148,11 @@ namespace Myra.Graphics2D.UI
             Vector2 mousePos = Vector2.Zero;
             if (ViewportAdapter.HasValue)
             {
-                var inv = Matrix.Invert(ViewportAdapter.Value.TransformMatrix);
+#if PLATFORM_AGNOSTIC
+                Matrix.Invert(ViewportAdapter.Value.TransformMatrix, out var inv);
+#else
+				var inv = Matrix.Invert(ViewportAdapter.Value.TransformMatrix);
+#endif
 #if STRIDE
 				var transformed = Vector2.Transform(mouseInfo.Position.ToVector2(), inv);
                 mousePos = new Vector2(transformed.X, transformed.Y);
@@ -212,7 +216,11 @@ namespace Myra.Graphics2D.UI
 
                 if (ViewportAdapter.HasValue)
                 {
-                    var inv = Matrix.Invert(ViewportAdapter.Value.TransformMatrix);
+#if PLATFORM_AGNOSTIC
+                    Matrix.Invert(ViewportAdapter.Value.TransformMatrix, out var inv);
+#else
+					var inv = Matrix.Invert(ViewportAdapter.Value.TransformMatrix);
+#endif
                     pos = Vector2.Transform(new Vector2(pos.X, pos.Y), inv);
                 }
 

--- a/src/Myra/Graphics2D/UI/Desktop.Input.cs
+++ b/src/Myra/Graphics2D/UI/Desktop.Input.cs
@@ -149,7 +149,13 @@ namespace Myra.Graphics2D.UI
             if (ViewportAdapter.HasValue)
             {
                 var inv = Matrix.Invert(ViewportAdapter.Value.TransformMatrix);
+#if STRIDE
+				var transformed = Vector2.Transform(mouseInfo.Position.ToVector2(), inv);
+                mousePos = new Vector2(transformed.X, transformed.Y);
+#else
+
                 mousePos = Vector2.Transform(mouseInfo.Position.ToVector2(), inv);
+#endif
             }
             else
             {

--- a/src/Myra/Graphics2D/UI/Desktop.Input.cs
+++ b/src/Myra/Graphics2D/UI/Desktop.Input.cs
@@ -145,11 +145,22 @@ namespace Myra.Graphics2D.UI
 
 			var mouseInfo = MyraEnvironment.MouseInfoGetter();
 
-			// Mouse Position
-			MousePosition = mouseInfo.Position;
+            Vector2 mousePos = Vector2.Zero;
+            if (ViewportAdapter.HasValue)
+            {
+                var inv = Matrix.Invert(ViewportAdapter.Value.TransformMatrix);
+                mousePos = Vector2.Transform(mouseInfo.Position.ToVector2(), inv);
+            }
+            else
+            {
+                mousePos = mouseInfo.Position.ToVector2();
+            }
 
-			// Touch Position
-			Point? touchPosition = null;
+            // Mouse Position
+            MousePosition = mousePos.ToPoint();
+
+            // Touch Position
+            Point? touchPosition = null;
 			if (mouseInfo.IsLeftButtonDown || mouseInfo.IsRightButtonDown || mouseInfo.IsMiddleButtonDown)
 			{
 				// Touch by mouse
@@ -192,7 +203,14 @@ namespace Myra.Graphics2D.UI
 			if (touchState.IsConnected && touchState.Count > 0)
 			{
 				var pos = touchState[0].Position;
-				TouchPosition = new Point((int)pos.X, (int)pos.Y);
+
+                if (ViewportAdapter.HasValue)
+                {
+                    var inv = Matrix.Invert(ViewportAdapter.Value.TransformMatrix);
+                    pos = Vector2.Transform(new Vector2(pos.X, pos.Y), inv);
+                }
+
+                TouchPosition = new Point((int)pos.X, (int)pos.Y);
 			}
 			else
 			{

--- a/src/Myra/Graphics2D/UI/Widget.cs
+++ b/src/Myra/Graphics2D/UI/Widget.cs
@@ -853,7 +853,15 @@ namespace Myra.Graphics2D.UI
 			if (context.Transform.Rotation.IsZero())
 			{
 				var absoluteBounds = context.Transform.Apply(Bounds);
-				var scissorBounds = Rectangle.Intersect(context.Scissor, absoluteBounds);
+
+                if (Desktop.ViewportAdapter.HasValue)
+                {
+                    // position stored in context.Transform, so we need apply Transform twice
+                    var scaledTransform = new Transform(context.TransformMatrix.Value, Vector2.One, 0);
+                    absoluteBounds = scaledTransform.Apply(absoluteBounds);
+                }
+
+                var scissorBounds = Rectangle.Intersect(context.Scissor, absoluteBounds);
 
 				if (scissorBounds.Width == 0 || scissorBounds.Height == 0)
 				{

--- a/src/Myra/MyraEnvironment.cs
+++ b/src/Myra/MyraEnvironment.cs
@@ -291,10 +291,12 @@ namespace Myra
 #if MONOGAME || FNA
 			var state = Mouse.GetState();
 
-			return new MouseInfo
-			{
-				Position = new Point(state.X, state.Y),
-				IsLeftButtonDown = Game.IsActive && state.LeftButton == ButtonState.Pressed,
+            var pos = new Point(state.X - GraphicsDevice.Viewport.X, state.Y - GraphicsDevice.Viewport.Y);
+
+            return new MouseInfo
+            {
+                Position = pos,
+                IsLeftButtonDown = Game.IsActive && state.LeftButton == ButtonState.Pressed,
 				IsMiddleButtonDown = Game.IsActive && state.MiddleButton == ButtonState.Pressed,
 				IsRightButtonDown = Game.IsActive && state.RightButton == ButtonState.Pressed,
 				Wheel = state.ScrollWheelValue


### PR DESCRIPTION
Added support for ViewboxAdapters and TransformationMatrix:
![MyraViewportAdapter](https://github.com/user-attachments/assets/a59aeb96-4369-4ee7-97b4-a271b127c386)

All you need for support `ViewportAdapter` and/or `TransformationMatrix` is setting up `ViewportAdapterFetcher` for desktop instance:
```C#
MyraDesktop.ViewportAdapterFetcher = () => new Myra.Graphics2D.MyraViewportAdapter()
{
    VirtualWidth = viewportAdapter.VirtualWidth,
    VirtualHeight = viewportAdapter.VirtualHeight,
    TransformMatrix = viewportAdapter.GetScaleMatrix()
};
```
