### PR TITLE
Added dimension types to height/width attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,4 @@ __pycache__/
 docfx/api
 !docfx/api/index.md
 docfx/_site
+/src/Myra/Properties/launchSettings.json

--- a/.gitignore
+++ b/.gitignore
@@ -264,4 +264,3 @@ __pycache__/
 docfx/api
 !docfx/api/index.md
 docfx/_site
-/src/Myra/Properties/launchSettings.json

--- a/src/Myra.Tests/DimensionTests.cs
+++ b/src/Myra.Tests/DimensionTests.cs
@@ -1,0 +1,208 @@
+﻿using Microsoft.Xna.Framework;
+using Myra.Graphics2D.UI;
+using Myra.Graphics2D.UI.Styles;
+using Myra.MML;
+using System.Xml.Linq;
+using Xunit;
+
+namespace Myra.Tests
+{
+	[Collection("Myra Tests")]
+	public class DimensionTests
+	{
+		[Fact]
+		public void DefinesExpectedDimensionTypes()
+		{
+			Assert.Equal(DimensionType.Auto, Dimension.Auto.Type);
+			Assert.Equal(DimensionType.Fill, Dimension.Fill.Type);
+			Assert.Equal(new Dimension(DimensionType.Pixel, 32), Dimension.Pixel(32));
+			Assert.Equal(new Dimension(DimensionType.Percent, 0.5f), Dimension.Percent(0.5f));
+		}
+
+		[Theory]
+		[InlineData("Auto", DimensionType.Auto, 0.0f)]
+		[InlineData("Fill", DimensionType.Fill, 0.0f)]
+		[InlineData("24px", DimensionType.Pixel, 24.0f)]
+		[InlineData("24", DimensionType.Pixel, 24.0f)]
+		[InlineData("50%", DimensionType.Percent, 0.5f)]
+		public void ParsesCommonDimensionStrings(string value, DimensionType expectedType, float expectedValue)
+		{
+			var dimension = Dimension.Parse(value);
+
+			Assert.Equal(expectedType, dimension.Type);
+			Assert.Equal(expectedValue, dimension.Value, 3);
+		}
+
+		[Fact]
+		public void RegistersDimensionSerializerForMML()
+		{
+			var serializer = BaseContext.FindSerializer(typeof(Dimension));
+
+			Assert.NotNull(serializer);
+			Assert.Equal(Dimension.Pixel(32), serializer.Deserialize("32px"));
+			Assert.Equal("25%", serializer.Serialize(Dimension.Percent(0.25f)));
+		}
+
+		[Fact]
+		public void PixelDimensionsMeasureLikeLegacyWidthAndHeight()
+		{
+			var panel = new Panel
+			{
+				WidthDimension = Dimension.Pixel(80),
+				HeightDimension = Dimension.Pixel(24)
+			};
+
+			Assert.Null(panel.Width);
+			Assert.Null(panel.Height);
+			Assert.Equal(new Point(80, 24), panel.Measure(new Point(500, 500)));
+		}
+
+		[Fact]
+		public void LegacyWidthAndHeightStillMeasureAsPixels()
+		{
+			var panel = new Panel
+			{
+				Width = 80,
+				Height = 24
+			};
+
+			Assert.Equal(Dimension.Auto, panel.WidthDimension);
+			Assert.Equal(Dimension.Auto, panel.HeightDimension);
+			Assert.Equal(new Point(80, 24), panel.Measure(new Point(500, 500)));
+		}
+
+		[Fact]
+		public void LegacyWidthAndHeightClearExplicitDimensions()
+		{
+			var panel = new Panel
+			{
+				WidthDimension = Dimension.Pixel(80),
+				HeightDimension = Dimension.Pixel(24)
+			};
+
+			panel.Width = 120;
+			panel.Height = 36;
+
+			Assert.Equal(Dimension.Auto, panel.WidthDimension);
+			Assert.Equal(Dimension.Auto, panel.HeightDimension);
+			Assert.Equal(new Point(120, 36), panel.Measure(new Point(500, 500)));
+		}
+
+		[Fact]
+		public void AutoDimensionsRestoreContentMeasurement()
+		{
+			var panel = new Panel
+			{
+				Width = 120,
+				Height = 36
+			};
+			panel.Widgets.Add(new Panel
+			{
+				Width = 80,
+				Height = 24
+			});
+
+			panel.WidthDimension = Dimension.Auto;
+			panel.HeightDimension = Dimension.Auto;
+
+			Assert.Null(panel.Width);
+			Assert.Null(panel.Height);
+			Assert.Equal(new Point(80, 24), panel.Measure(new Point(500, 500)));
+		}
+
+		[Fact]
+		public void FillDimensionsUseAvailableSize()
+		{
+			var panel = new Panel
+			{
+				WidthDimension = Dimension.Fill,
+				HeightDimension = Dimension.Fill
+			};
+
+			Assert.Equal(new Point(200, 100), panel.Measure(new Point(200, 100)));
+
+			panel.Arrange(new Rectangle(0, 0, 200, 100));
+
+			Assert.Equal(new Rectangle(0, 0, 200, 100), panel.Bounds);
+		}
+
+		[Fact]
+		public void PercentDimensionsUseAvailableSize()
+		{
+			var panel = new Panel
+			{
+				WidthDimension = Dimension.Percent(0.5f),
+				HeightDimension = Dimension.Percent(0.25f)
+			};
+
+			Assert.Equal(new Point(100, 25), panel.Measure(new Point(200, 100)));
+
+			panel.Arrange(new Rectangle(0, 0, 200, 100));
+
+			Assert.Equal(new Rectangle(0, 0, 100, 25), panel.Bounds);
+		}
+
+		[Fact]
+		public void CanLoadPixelDimensionsFromMML()
+		{
+			var project = Project.LoadFromXml("<Project><Panel WidthDimension=\"80px\" HeightDimension=\"24px\" /></Project>");
+			var panel = Assert.IsType<Panel>(project.Root);
+
+			Assert.Equal(Dimension.Pixel(80), panel.WidthDimension);
+			Assert.Equal(Dimension.Pixel(24), panel.HeightDimension);
+			Assert.Null(panel.Width);
+			Assert.Null(panel.Height);
+			Assert.Equal(new Point(80, 24), panel.Measure(new Point(500, 500)));
+		}
+
+		[Fact]
+		public void CanLoadFillAndPercentDimensionsFromMML()
+		{
+			var project = Project.LoadFromXml("<Project><Panel WidthDimension=\"Fill\" HeightDimension=\"25%\" /></Project>");
+			var panel = Assert.IsType<Panel>(project.Root);
+
+			Assert.Equal(Dimension.Fill, panel.WidthDimension);
+			Assert.Equal(Dimension.Percent(0.25f), panel.HeightDimension);
+			Assert.Equal(new Point(200, 25), panel.Measure(new Point(200, 100)));
+		}
+
+		[Fact]
+		public void SavesImplementedDimensionAttributes()
+		{
+			var project = Project.LoadFromXml("<Project><Panel WidthDimension=\"Fill\" HeightDimension=\"25%\" /></Project>");
+
+			var element = XDocument.Parse(project.ToXml()).Root.Element("Panel");
+
+			Assert.Equal("Fill", element.Attribute("WidthDimension").Value);
+			Assert.Equal("25%", element.Attribute("HeightDimension").Value);
+			Assert.Null(element.Attribute("Width"));
+			Assert.Null(element.Attribute("Height"));
+		}
+
+		[Fact]
+		public void LegacyWidthMMLDoesNotSaveDimensionAttributes()
+		{
+			var project = Project.LoadFromXml("<Project><Panel Width=\"80\" Height=\"24\" /></Project>");
+
+			var element = XDocument.Parse(project.ToXml()).Root.Element("Panel");
+
+			Assert.Equal("80", element.Attribute("Width").Value);
+			Assert.Equal("24", element.Attribute("Height").Value);
+			Assert.Null(element.Attribute("WidthDimension"));
+			Assert.Null(element.Attribute("HeightDimension"));
+		}
+
+		[Fact]
+		public void WidgetStyleCanApplyDimensions()
+		{
+			var panel = new Panel();
+			panel.ApplyWidgetStyle(new WidgetStyle
+			{
+				WidthDimension = Dimension.Percent(0.5f),
+				HeightDimension = Dimension.Fill
+			});
+
+			Assert.Equal(new Point(100, 100), panel.Measure(new Point(200, 100)));
+		}
+	}
+}

--- a/src/Myra.Tests/DimensionTests.cs
+++ b/src/Myra.Tests/DimensionTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
 using Myra.Graphics2D.UI;
 using Myra.Graphics2D.UI.Styles;
 using Myra.MML;
@@ -40,25 +40,26 @@ namespace Myra.Tests
 
 			Assert.NotNull(serializer);
 			Assert.Equal(Dimension.Pixel(32), serializer.Deserialize("32px"));
+			Assert.Equal("32", serializer.Serialize(Dimension.Pixel(32)));
 			Assert.Equal("25%", serializer.Serialize(Dimension.Percent(0.25f)));
 		}
 
 		[Fact]
-		public void PixelDimensionsMeasureLikeLegacyWidthAndHeight()
+		public void PixelWidthAndHeightMeasureToFixedSize()
 		{
 			var panel = new Panel
 			{
-				WidthDimension = Dimension.Pixel(80),
-				HeightDimension = Dimension.Pixel(24)
+				Width = Dimension.Pixel(80),
+				Height = Dimension.Pixel(24)
 			};
 
-			Assert.Null(panel.Width);
-			Assert.Null(panel.Height);
+			Assert.Equal(Dimension.Pixel(80), panel.Width);
+			Assert.Equal(Dimension.Pixel(24), panel.Height);
 			Assert.Equal(new Point(80, 24), panel.Measure(new Point(500, 500)));
 		}
 
 		[Fact]
-		public void LegacyWidthAndHeightStillMeasureAsPixels()
+		public void NumericWidthAndHeightStillMeasureAsPixels()
 		{
 			var panel = new Panel
 			{
@@ -66,25 +67,25 @@ namespace Myra.Tests
 				Height = 24
 			};
 
-			Assert.Equal(Dimension.Auto, panel.WidthDimension);
-			Assert.Equal(Dimension.Auto, panel.HeightDimension);
+			Assert.Equal(Dimension.Pixel(80), panel.Width);
+			Assert.Equal(Dimension.Pixel(24), panel.Height);
 			Assert.Equal(new Point(80, 24), panel.Measure(new Point(500, 500)));
 		}
 
 		[Fact]
-		public void LegacyWidthAndHeightClearExplicitDimensions()
+		public void NumericWidthAndHeightReplacePreviousDimensions()
 		{
 			var panel = new Panel
 			{
-				WidthDimension = Dimension.Pixel(80),
-				HeightDimension = Dimension.Pixel(24)
+				Width = Dimension.Percent(0.5f),
+				Height = Dimension.Fill
 			};
 
 			panel.Width = 120;
 			panel.Height = 36;
 
-			Assert.Equal(Dimension.Auto, panel.WidthDimension);
-			Assert.Equal(Dimension.Auto, panel.HeightDimension);
+			Assert.Equal(Dimension.Pixel(120), panel.Width);
+			Assert.Equal(Dimension.Pixel(36), panel.Height);
 			Assert.Equal(new Point(120, 36), panel.Measure(new Point(500, 500)));
 		}
 
@@ -102,11 +103,11 @@ namespace Myra.Tests
 				Height = 24
 			});
 
-			panel.WidthDimension = Dimension.Auto;
-			panel.HeightDimension = Dimension.Auto;
+			panel.Width = Dimension.Auto;
+			panel.Height = Dimension.Auto;
 
-			Assert.Null(panel.Width);
-			Assert.Null(panel.Height);
+			Assert.Equal(Dimension.Auto, panel.Width);
+			Assert.Equal(Dimension.Auto, panel.Height);
 			Assert.Equal(new Point(80, 24), panel.Measure(new Point(500, 500)));
 		}
 
@@ -115,8 +116,8 @@ namespace Myra.Tests
 		{
 			var panel = new Panel
 			{
-				WidthDimension = Dimension.Fill,
-				HeightDimension = Dimension.Fill
+				Width = Dimension.Fill,
+				Height = Dimension.Fill
 			};
 
 			Assert.Equal(new Point(200, 100), panel.Measure(new Point(200, 100)));
@@ -131,8 +132,8 @@ namespace Myra.Tests
 		{
 			var panel = new Panel
 			{
-				WidthDimension = Dimension.Percent(0.5f),
-				HeightDimension = Dimension.Percent(0.25f)
+				Width = Dimension.Percent(0.5f),
+				Height = Dimension.Percent(0.25f)
 			};
 
 			Assert.Equal(new Point(100, 25), panel.Measure(new Point(200, 100)));
@@ -145,42 +146,40 @@ namespace Myra.Tests
 		[Fact]
 		public void CanLoadPixelDimensionsFromMML()
 		{
-			var project = Project.LoadFromXml("<Project><Panel WidthDimension=\"80px\" HeightDimension=\"24px\" /></Project>");
+			var project = Project.LoadFromXml("<Project><Panel Width=\"80px\" Height=\"24px\" /></Project>");
 			var panel = Assert.IsType<Panel>(project.Root);
 
-			Assert.Equal(Dimension.Pixel(80), panel.WidthDimension);
-			Assert.Equal(Dimension.Pixel(24), panel.HeightDimension);
-			Assert.Null(panel.Width);
-			Assert.Null(panel.Height);
+			Assert.Equal(Dimension.Pixel(80), panel.Width);
+			Assert.Equal(Dimension.Pixel(24), panel.Height);
 			Assert.Equal(new Point(80, 24), panel.Measure(new Point(500, 500)));
 		}
 
 		[Fact]
 		public void CanLoadFillAndPercentDimensionsFromMML()
 		{
-			var project = Project.LoadFromXml("<Project><Panel WidthDimension=\"Fill\" HeightDimension=\"25%\" /></Project>");
+			var project = Project.LoadFromXml("<Project><Panel Width=\"Fill\" Height=\"25%\" /></Project>");
 			var panel = Assert.IsType<Panel>(project.Root);
 
-			Assert.Equal(Dimension.Fill, panel.WidthDimension);
-			Assert.Equal(Dimension.Percent(0.25f), panel.HeightDimension);
+			Assert.Equal(Dimension.Fill, panel.Width);
+			Assert.Equal(Dimension.Percent(0.25f), panel.Height);
 			Assert.Equal(new Point(200, 25), panel.Measure(new Point(200, 100)));
 		}
 
 		[Fact]
 		public void SavesImplementedDimensionAttributes()
 		{
-			var project = Project.LoadFromXml("<Project><Panel WidthDimension=\"Fill\" HeightDimension=\"25%\" /></Project>");
+			var project = Project.LoadFromXml("<Project><Panel Width=\"Fill\" Height=\"25%\" /></Project>");
 
 			var element = XDocument.Parse(project.ToXml()).Root.Element("Panel");
 
-			Assert.Equal("Fill", element.Attribute("WidthDimension").Value);
-			Assert.Equal("25%", element.Attribute("HeightDimension").Value);
-			Assert.Null(element.Attribute("Width"));
-			Assert.Null(element.Attribute("Height"));
+			Assert.Equal("Fill", element.Attribute("Width").Value);
+			Assert.Equal("25%", element.Attribute("Height").Value);
+			Assert.Null(element.Attribute("WidthDimension"));
+			Assert.Null(element.Attribute("HeightDimension"));
 		}
 
 		[Fact]
-		public void LegacyWidthMMLDoesNotSaveDimensionAttributes()
+		public void NumericWidthMMLSavesPlainPixelAttributes()
 		{
 			var project = Project.LoadFromXml("<Project><Panel Width=\"80\" Height=\"24\" /></Project>");
 
@@ -198,8 +197,8 @@ namespace Myra.Tests
 			var panel = new Panel();
 			panel.ApplyWidgetStyle(new WidgetStyle
 			{
-				WidthDimension = Dimension.Percent(0.5f),
-				HeightDimension = Dimension.Fill
+				Width = Dimension.Percent(0.5f),
+				Height = Dimension.Fill
 			});
 
 			Assert.Equal(new Point(100, 100), panel.Measure(new Point(200, 100)));

--- a/src/Myra.Tests/SelectorsTests.cs
+++ b/src/Myra.Tests/SelectorsTests.cs
@@ -19,8 +19,8 @@ namespace Myra.Tests
 			Assert.IsType<ListView>(panel.Widgets[0]);
 			var listView = (ListView)panel.Widgets[0];
 
-			Assert.Equal(200, listView.Width);
-			Assert.Equal(200, listView.Height);
+			Assert.Equal(Dimension.Pixel(200), listView.Width);
+			Assert.Equal(Dimension.Pixel(200), listView.Height);
 			Assert.Equal(HorizontalAlignment.Center, listView.HorizontalAlignment);
 			Assert.Equal(VerticalAlignment.Center, listView.VerticalAlignment);
 			Assert.Equal(6, listView.Widgets.Count);
@@ -92,8 +92,8 @@ namespace Myra.Tests
 
 			Assert.IsType<Image>(horizontalStackPanel.Widgets[0]);
 			var image1 = (Image)horizontalStackPanel.Widgets[0];
-			Assert.Equal(16, image1.Width);
-			Assert.Equal(16, image1.Height);
+			Assert.Equal(Dimension.Pixel(16), image1.Width);
+			Assert.Equal(Dimension.Pixel(16), image1.Height);
 			Assert.NotNull(image1.Renderable);
 			Assert.Equal(64, image1.Renderable.Size.X);
 			Assert.Equal(64, image1.Renderable.Size.Y);

--- a/src/Myra.Tests/SimpleWidgetsTests.cs
+++ b/src/Myra.Tests/SimpleWidgetsTests.cs
@@ -142,7 +142,7 @@ namespace Myra.Tests
 
 			Assert.Equal(HorizontalAlignment.Center, textBox.HorizontalAlignment);
 			Assert.Equal(VerticalAlignment.Center, textBox.VerticalAlignment);
-			Assert.Equal(100, textBox.Width);
+			Assert.Equal(Dimension.Pixel(100), textBox.Width);
 		}
 	}
 }

--- a/src/Myra/Graphics2D/UI/Containers/SplitPane.cs
+++ b/src/Myra/Graphics2D/UI/Containers/SplitPane.cs
@@ -362,11 +362,11 @@ namespace Myra.Graphics2D.UI
 				if (Orientation == Orientation.Horizontal)
 				{
 					h.Width = handleSize;
-					h.Height = null;  // Let height stretch to fill available space
+					h.Height = Dimension.Auto;  // Let height stretch to fill available space
 				}
 				else
 				{
-					h.Width = null;  // Let width stretch to fill available space
+					h.Width = Dimension.Auto;  // Let width stretch to fill available space
 					h.Height = handleSize;
 				}
 			}

--- a/src/Myra/Graphics2D/UI/Data/DataGrid.cs
+++ b/src/Myra/Graphics2D/UI/Data/DataGrid.cs
@@ -1062,7 +1062,7 @@ namespace Myra.Graphics2D.UI.Data
 					_dataWidgets.Clear();
 				}
 
-				_grid.Width = null;
+				_grid.Width = Dimension.Auto;
 
 				if (size.X == 0 || size.Y == 0 || _data == null)
 				{

--- a/src/Myra/Graphics2D/UI/Dimension.cs
+++ b/src/Myra/Graphics2D/UI/Dimension.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 
 namespace Myra.Graphics2D.UI
@@ -11,29 +11,33 @@ namespace Myra.Graphics2D.UI
 		Percent
 	}
 
-	/// <summary>
-	/// Represents a widget dimension independent of the legacy nullable pixel width/height properties.
-	/// </summary>
 	public struct Dimension : IEquatable<Dimension>
 	{
-		public static readonly Dimension Auto = new Dimension(DimensionType.Auto);
-		public static readonly Dimension Fill = new Dimension(DimensionType.Fill);
+		public static Dimension Auto => new Dimension(DimensionType.Auto);
+		public static Dimension Fill => new Dimension(DimensionType.Fill);
 
-		public DimensionType Type { get; }
+		public DimensionType Type { get; set; }
+		public float Value { get; set; }
 
-		public float Value { get; }
-
-
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Dimension"/> struct.
+		/// </summary>
+		/// <param name="type">The dimension type.</param>
+		/// <param name="value">The dimension value.</param>
 		public Dimension(DimensionType type, float value = 0.0f)
 		{
 			Type = type;
 			Value = value;
 		}
+
 		public static Dimension Pixel(float value) => new Dimension(DimensionType.Pixel, value);
+
 		public static Dimension Percent(float value) => new Dimension(DimensionType.Percent, value);
+		
+		public static implicit operator Dimension(int value) => Pixel(value);
 
+		public static implicit operator Dimension(float value) => Pixel(value);
 
-		// Returns type based off suffix
 		public static Dimension Parse(string value)
 		{
 			if (value == null)
@@ -59,12 +63,14 @@ namespace Myra.Graphics2D.UI
 
 			if (value.EndsWith("%", StringComparison.Ordinal))
 			{
-				return Percent(ParseFloat(value.Substring(0, value.Length - 1)) / 100.0f);
+				var percent = ParseFloat(value.Substring(0, value.Length - 1));
+				return Percent(percent / 100.0f);
 			}
 
 			if (value.EndsWith("px", StringComparison.OrdinalIgnoreCase))
 			{
-				return Pixel(ParseFloat(value.Substring(0, value.Length - 2)));
+				var pixels = ParseFloat(value.Substring(0, value.Length - 2));
+				return Pixel(pixels);
 			}
 
 			return Pixel(ParseFloat(value));
@@ -80,13 +86,13 @@ namespace Myra.Graphics2D.UI
 				case DimensionType.Percent:
 					return FormatFloat(Value * 100.0f) + "%";
 				default:
-					return FormatFloat(Value) + "px";
+					return FormatFloat(Value);
 			}
 		}
 
 		public bool Equals(Dimension other) => Type == other.Type && Value.Equals(other.Value);
-		public override bool Equals(object obj) => obj is Dimension other && Equals(other);
 
+		public override bool Equals(object obj) => obj is Dimension other && Equals(other);
 
 		public static bool operator ==(Dimension left, Dimension right) => left.Equals(right);
 

--- a/src/Myra/Graphics2D/UI/Dimension.cs
+++ b/src/Myra/Graphics2D/UI/Dimension.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Globalization;
+
+namespace Myra.Graphics2D.UI
+{
+	public enum DimensionType
+	{
+		Auto,
+		Pixel,
+		Fill,
+		Percent
+	}
+
+	/// <summary>
+	/// Represents a widget dimension independent of the legacy nullable pixel width/height properties.
+	/// </summary>
+	public struct Dimension : IEquatable<Dimension>
+	{
+		public static readonly Dimension Auto = new Dimension(DimensionType.Auto);
+		public static readonly Dimension Fill = new Dimension(DimensionType.Fill);
+
+		public DimensionType Type { get; }
+
+		public float Value { get; }
+
+
+		public Dimension(DimensionType type, float value = 0.0f)
+		{
+			Type = type;
+			Value = value;
+		}
+		public static Dimension Pixel(float value) => new Dimension(DimensionType.Pixel, value);
+		public static Dimension Percent(float value) => new Dimension(DimensionType.Percent, value);
+
+
+		// Returns type based off suffix
+		public static Dimension Parse(string value)
+		{
+			if (value == null)
+			{
+				throw new ArgumentNullException(nameof(value));
+			}
+
+			value = value.Trim();
+			if (value.Length == 0)
+			{
+				throw new FormatException("Dimension value cannot be empty.");
+			}
+
+			if (string.Equals(value, nameof(DimensionType.Auto), StringComparison.OrdinalIgnoreCase))
+			{
+				return Auto;
+			}
+
+			if (string.Equals(value, nameof(DimensionType.Fill), StringComparison.OrdinalIgnoreCase))
+			{
+				return Fill;
+			}
+
+			if (value.EndsWith("%", StringComparison.Ordinal))
+			{
+				return Percent(ParseFloat(value.Substring(0, value.Length - 1)) / 100.0f);
+			}
+
+			if (value.EndsWith("px", StringComparison.OrdinalIgnoreCase))
+			{
+				return Pixel(ParseFloat(value.Substring(0, value.Length - 2)));
+			}
+
+			return Pixel(ParseFloat(value));
+		}
+
+		public override string ToString()
+		{
+			switch (Type)
+			{
+				case DimensionType.Auto:
+				case DimensionType.Fill:
+					return Type.ToString();
+				case DimensionType.Percent:
+					return FormatFloat(Value * 100.0f) + "%";
+				default:
+					return FormatFloat(Value) + "px";
+			}
+		}
+
+		public bool Equals(Dimension other) => Type == other.Type && Value.Equals(other.Value);
+		public override bool Equals(object obj) => obj is Dimension other && Equals(other);
+
+
+		public static bool operator ==(Dimension left, Dimension right) => left.Equals(right);
+
+		public static bool operator !=(Dimension left, Dimension right) => !left.Equals(right);
+
+		private static float ParseFloat(string value) => float.Parse(value.Trim(), CultureInfo.InvariantCulture);
+
+		private static string FormatFloat(float value) => value.ToString("0.###", CultureInfo.InvariantCulture);
+	}
+}

--- a/src/Myra/Graphics2D/UI/Selectors/ComboView.cs
+++ b/src/Myra/Graphics2D/UI/Selectors/ComboView.cs
@@ -260,7 +260,7 @@ namespace Myra.Graphics2D.UI
 
 			// Temporary remove width, so it wont be used in the measure
 			var oldWidth = _listView.Width;
-			_listView.Width = null;
+			_listView.Width = Dimension.Auto;
 
 			// Make visible, otherwise Measure will return zero
 			var wasVisible = _listView.Visible;

--- a/src/Myra/Graphics2D/UI/Selectors/TabControl.cs
+++ b/src/Myra/Graphics2D/UI/Selectors/TabControl.cs
@@ -282,7 +282,7 @@ namespace Myra.Graphics2D.UI
 			{
 				HorizontalAlignment = HorizontalAlignment.Stretch,
 				VerticalAlignment = VerticalAlignment.Stretch,
-				Height = item.Height,
+				Height = item.Height.HasValue ? Dimension.Pixel(item.Height.Value) : Dimension.Auto,
 				Content = panel,
 				ButtonsContainer = _gridButtons
 			};

--- a/src/Myra/Graphics2D/UI/Styles/WidgetStyle.cs
+++ b/src/Myra/Graphics2D/UI/Styles/WidgetStyle.cs
@@ -19,11 +19,17 @@ namespace Myra.Graphics2D.UI.Styles
 		[Category("Layout")]
 		public int? Width { get; set; }
 
+		[Category("Layout")]
+		public Dimension? WidthDimension { get; set; }
+
 		/// <summary>
 		/// Gets or sets the fixed height of the widget in pixels, or null for auto-sizing.
 		/// </summary>
 		[Category("Layout")]
 		public int? Height { get; set; }
+
+		[Category("Layout")]
+		public Dimension? HeightDimension { get; set; }
 
 		/// <summary>
 		/// Gets or sets the minimum width of the widget in pixels, or null for no minimum.
@@ -142,6 +148,8 @@ namespace Myra.Graphics2D.UI.Styles
 		{
 			Width = style.Width;
 			Height = style.Height;
+			WidthDimension = style.WidthDimension;
+			HeightDimension = style.HeightDimension;
 			MinWidth = style.MinWidth;
 			MinHeight = style.MinHeight;
 			MaxWidth = style.MaxWidth;

--- a/src/Myra/Graphics2D/UI/Styles/WidgetStyle.cs
+++ b/src/Myra/Graphics2D/UI/Styles/WidgetStyle.cs
@@ -14,22 +14,16 @@ namespace Myra.Graphics2D.UI.Styles
 		public string Id { get; set; }
 
 		/// <summary>
-		/// Gets or sets the fixed width of the widget in pixels, or null for auto-sizing.
+		/// Gets or sets the width of the widget, or null for auto-sizing.
 		/// </summary>
 		[Category("Layout")]
-		public int? Width { get; set; }
-
-		[Category("Layout")]
-		public Dimension? WidthDimension { get; set; }
+		public Dimension? Width { get; set; }
 
 		/// <summary>
-		/// Gets or sets the fixed height of the widget in pixels, or null for auto-sizing.
+		/// Gets or sets the height of the widget, or null for auto-sizing.
 		/// </summary>
 		[Category("Layout")]
-		public int? Height { get; set; }
-
-		[Category("Layout")]
-		public Dimension? HeightDimension { get; set; }
+		public Dimension? Height { get; set; }
 
 		/// <summary>
 		/// Gets or sets the minimum width of the widget in pixels, or null for no minimum.
@@ -148,8 +142,6 @@ namespace Myra.Graphics2D.UI.Styles
 		{
 			Width = style.Width;
 			Height = style.Height;
-			WidthDimension = style.WidthDimension;
-			HeightDimension = style.HeightDimension;
 			MinWidth = style.MinWidth;
 			MinHeight = style.MinHeight;
 			MaxWidth = style.MaxWidth;

--- a/src/Myra/Graphics2D/UI/Widget.cs
+++ b/src/Myra/Graphics2D/UI/Widget.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using Myra.Graphics2D.UI.Styles;
 using Myra.Utility;
@@ -67,8 +67,8 @@ namespace Myra.Graphics2D.UI
 		private Point _startLeftTop;
 		private Thickness _margin, _borderThickness, _padding;
 		private int _left, _top;
-		private int? _minWidth, _minHeight, _maxWidth, _maxHeight, _width, _height;
-		private Dimension _widthDimension, _heightDimension;
+		private int? _minWidth, _minHeight, _maxWidth, _maxHeight;
+		private Dimension _width, _height;
 		private int _zIndex;
 		private HorizontalAlignment _horizontalAlignment = HorizontalAlignment.Left;
 		private VerticalAlignment _verticalAlignment = VerticalAlignment.Top;
@@ -187,11 +187,11 @@ namespace Myra.Graphics2D.UI
 		}
 
 		/// <summary>
-		/// Gets or sets the width of the widget in pixels.
+		/// Gets or sets the width of the widget.
 		/// </summary>
 		[Category("Layout")]
-		[DefaultValue(null)]
-		public int? Width
+		[DefaultValue("Auto")]
+		public Dimension Width
 		{
 			get
 			{
@@ -200,36 +200,12 @@ namespace Myra.Graphics2D.UI
 
 			set
 			{
-				if (value == _width && _widthDimension == Dimension.Auto)
+				if (_width.Equals(value))
 				{
 					return;
 				}
 
 				_width = value;
-				_widthDimension = Dimension.Auto;
-				InvalidateMeasure();
-				FireSizeChanged();
-			}
-		}
-
-		[Category("Layout")]
-		[DefaultValue("Auto")]
-		public Dimension WidthDimension
-		{
-			get
-			{
-				return _widthDimension;
-			}
-
-			set
-			{
-				if (value == _widthDimension && (!value.Equals(Dimension.Auto) || !_width.HasValue))
-				{
-					return;
-				}
-
-				_widthDimension = value;
-				_width = null;
 				InvalidateMeasure();
 				FireSizeChanged();
 			}
@@ -278,11 +254,11 @@ namespace Myra.Graphics2D.UI
 		}
 
 		/// <summary>
-		/// Gets or sets the height of the widget in pixels.
+		/// Gets or sets the height of the widget.
 		/// </summary>
 		[Category("Layout")]
-		[DefaultValue(null)]
-		public int? Height
+		[DefaultValue("Auto")]
+		public Dimension Height
 		{
 			get
 			{
@@ -291,36 +267,12 @@ namespace Myra.Graphics2D.UI
 
 			set
 			{
-				if (value == _height && _heightDimension == Dimension.Auto)
+				if (_height.Equals(value))
 				{
 					return;
 				}
 
 				_height = value;
-				_heightDimension = Dimension.Auto;
-				InvalidateMeasure();
-				FireSizeChanged();
-			}
-		}
-
-		[Category("Layout")]
-		[DefaultValue("Auto")]
-		public Dimension HeightDimension
-		{
-			get
-			{
-				return _heightDimension;
-			}
-
-			set
-			{
-				if (value == _heightDimension && (!value.Equals(Dimension.Auto) || !_height.HasValue))
-				{
-					return;
-				}
-
-				_heightDimension = value;
-				_height = null;
 				InvalidateMeasure();
 				FireSizeChanged();
 			}
@@ -1221,17 +1173,17 @@ namespace Myra.Graphics2D.UI
 			}
 		}
 
-		private int? ResolveWidthDimension(int availableWidth)
+		private int? ResolveWidth(int availableWidth)
 		{
-			return ResolveDimension(_widthDimension, _width, availableWidth);
+			return ResolveDimension(_width, availableWidth);
 		}
 
-		private int? ResolveHeightDimension(int availableHeight)
+		private int? ResolveHeight(int availableHeight)
 		{
-			return ResolveDimension(_heightDimension, _height, availableHeight);
+			return ResolveDimension(_height, availableHeight);
 		}
 
-		private static int? ResolveDimension(Dimension dimension, int? legacy, int availableSize)
+		private static int? ResolveDimension(Dimension dimension, int availableSize)
 		{
 			switch (dimension.Type)
 			{
@@ -1242,7 +1194,7 @@ namespace Myra.Graphics2D.UI
 				case DimensionType.Percent:
 					return (int)(availableSize * dimension.Value);
 				default:
-					return legacy;
+					return null;
 			}
 		}
 
@@ -1260,8 +1212,8 @@ namespace Myra.Graphics2D.UI
 
 			Point result;
 
-			var width = ResolveWidthDimension(availableSize.X);
-			var height = ResolveHeightDimension(availableSize.Y);
+			var width = ResolveWidth(availableSize.X);
+			var height = ResolveHeight(availableSize.Y);
 
 			// Lerp available size by Width/Height or MaxWidth/MaxHeight
 			if (width != null && availableSize.X > width.Value)
@@ -1385,8 +1337,8 @@ namespace Myra.Graphics2D.UI
 
 			// Resolve possible conflict beetween Alignment set to Streth and Size explicitly set
 			var containerSize = _containerBounds.Size();
-			var width = ResolveWidthDimension(containerSize.X);
-			var height = ResolveHeightDimension(containerSize.Y);
+			var width = ResolveWidth(containerSize.X);
+			var height = ResolveHeight(containerSize.Y);
 			if (HorizontalAlignment == HorizontalAlignment.Stretch && width != null && width.Value < containerSize.X)
 			{
 				containerSize.X = width.Value;
@@ -1571,17 +1523,8 @@ namespace Myra.Graphics2D.UI
 		/// <param name="style">The widget style to apply.</param>
 		protected virtual void ApplyStyle(WidgetStyle style)
 		{
-			Width = style.Width;
-			Height = style.Height;
-			if (style.WidthDimension.HasValue)
-			{
-				WidthDimension = style.WidthDimension.Value;
-			}
-
-			if (style.HeightDimension.HasValue)
-			{
-				HeightDimension = style.HeightDimension.Value;
-			}
+			Width = style.Width ?? Dimension.Auto;
+			Height = style.Height ?? Dimension.Auto;
 			MinWidth = style.MinWidth;
 			MinHeight = style.MinHeight;
 			MaxWidth = style.MaxWidth;
@@ -1997,25 +1940,11 @@ namespace Myra.Graphics2D.UI
 			Top = w.Top;
 			MinWidth = w.MinWidth;
 			MaxWidth = w.MaxWidth;
-			if (w.WidthDimension != Dimension.Auto)
-			{
-				WidthDimension = w.WidthDimension;
-			}
-			else
-			{
-				Width = w.Width;
-			}
+			Width = w.Width;
 
 			MinHeight = w.MinHeight;
 			MaxHeight = w.MaxHeight;
-			if (w.HeightDimension != Dimension.Auto)
-			{
-				HeightDimension = w.HeightDimension;
-			}
-			else
-			{
-				Height = w.Height;
-			}
+			Height = w.Height;
 
 			Margin = w.Margin;
 			BorderThickness = w.BorderThickness;

--- a/src/Myra/Graphics2D/UI/Widget.cs
+++ b/src/Myra/Graphics2D/UI/Widget.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.ComponentModel;
 using Myra.Graphics2D.UI.Styles;
 using Myra.Utility;
@@ -68,6 +68,7 @@ namespace Myra.Graphics2D.UI
 		private Thickness _margin, _borderThickness, _padding;
 		private int _left, _top;
 		private int? _minWidth, _minHeight, _maxWidth, _maxHeight, _width, _height;
+		private Dimension _widthDimension, _heightDimension;
 		private int _zIndex;
 		private HorizontalAlignment _horizontalAlignment = HorizontalAlignment.Left;
 		private VerticalAlignment _verticalAlignment = VerticalAlignment.Top;
@@ -199,12 +200,36 @@ namespace Myra.Graphics2D.UI
 
 			set
 			{
-				if (value == _width)
+				if (value == _width && _widthDimension == Dimension.Auto)
 				{
 					return;
 				}
 
 				_width = value;
+				_widthDimension = Dimension.Auto;
+				InvalidateMeasure();
+				FireSizeChanged();
+			}
+		}
+
+		[Category("Layout")]
+		[DefaultValue("Auto")]
+		public Dimension WidthDimension
+		{
+			get
+			{
+				return _widthDimension;
+			}
+
+			set
+			{
+				if (value == _widthDimension && (!value.Equals(Dimension.Auto) || !_width.HasValue))
+				{
+					return;
+				}
+
+				_widthDimension = value;
+				_width = null;
 				InvalidateMeasure();
 				FireSizeChanged();
 			}
@@ -266,12 +291,36 @@ namespace Myra.Graphics2D.UI
 
 			set
 			{
-				if (value == _height)
+				if (value == _height && _heightDimension == Dimension.Auto)
 				{
 					return;
 				}
 
 				_height = value;
+				_heightDimension = Dimension.Auto;
+				InvalidateMeasure();
+				FireSizeChanged();
+			}
+		}
+
+		[Category("Layout")]
+		[DefaultValue("Auto")]
+		public Dimension HeightDimension
+		{
+			get
+			{
+				return _heightDimension;
+			}
+
+			set
+			{
+				if (value == _heightDimension && (!value.Equals(Dimension.Auto) || !_height.HasValue))
+				{
+					return;
+				}
+
+				_heightDimension = value;
+				_height = null;
 				InvalidateMeasure();
 				FireSizeChanged();
 			}
@@ -1172,6 +1221,31 @@ namespace Myra.Graphics2D.UI
 			}
 		}
 
+		private int? ResolveWidthDimension(int availableWidth)
+		{
+			return ResolveDimension(_widthDimension, _width, availableWidth);
+		}
+
+		private int? ResolveHeightDimension(int availableHeight)
+		{
+			return ResolveDimension(_heightDimension, _height, availableHeight);
+		}
+
+		private static int? ResolveDimension(Dimension dimension, int? legacy, int availableSize)
+		{
+			switch (dimension.Type)
+			{
+				case DimensionType.Pixel:
+					return (int)dimension.Value;
+				case DimensionType.Fill:
+					return availableSize;
+				case DimensionType.Percent:
+					return (int)(availableSize * dimension.Value);
+				default:
+					return legacy;
+			}
+		}
+
 		/// <summary>
 		/// Measures the widget to determine its desired size based on available space.
 		/// </summary>
@@ -1186,19 +1260,22 @@ namespace Myra.Graphics2D.UI
 
 			Point result;
 
+			var width = ResolveWidthDimension(availableSize.X);
+			var height = ResolveHeightDimension(availableSize.Y);
+
 			// Lerp available size by Width/Height or MaxWidth/MaxHeight
-			if (Width != null && availableSize.X > Width.Value)
+			if (width != null && availableSize.X > width.Value)
 			{
-				availableSize.X = Width.Value;
+				availableSize.X = width.Value;
 			}
 			else if (MaxWidth != null && availableSize.X > MaxWidth.Value)
 			{
 				availableSize.X = MaxWidth.Value;
 			}
 
-			if (Height != null && availableSize.Y > Height.Value)
+			if (height != null && availableSize.Y > height.Value)
 			{
-				availableSize.Y = Height.Value;
+				availableSize.Y = height.Value;
 			}
 			else if (MaxHeight != null && availableSize.Y > MaxHeight.Value)
 			{
@@ -1218,9 +1295,9 @@ namespace Myra.Graphics2D.UI
 			result.Y += MBPHeight;
 
 			// Result lerp
-			if (Width.HasValue)
+			if (width.HasValue)
 			{
-				result.X = Width.Value;
+				result.X = width.Value;
 			}
 			else
 			{
@@ -1235,9 +1312,9 @@ namespace Myra.Graphics2D.UI
 				}
 			}
 
-			if (Height.HasValue)
+			if (height.HasValue)
 			{
-				result.Y = Height.Value;
+				result.Y = height.Value;
 			}
 			else
 			{
@@ -1308,14 +1385,16 @@ namespace Myra.Graphics2D.UI
 
 			// Resolve possible conflict beetween Alignment set to Streth and Size explicitly set
 			var containerSize = _containerBounds.Size();
-			if (HorizontalAlignment == HorizontalAlignment.Stretch && Width != null && Width.Value < containerSize.X)
+			var width = ResolveWidthDimension(containerSize.X);
+			var height = ResolveHeightDimension(containerSize.Y);
+			if (HorizontalAlignment == HorizontalAlignment.Stretch && width != null && width.Value < containerSize.X)
 			{
-				containerSize.X = Width.Value;
+				containerSize.X = width.Value;
 			}
 
-			if (VerticalAlignment == VerticalAlignment.Stretch && Height != null && Height.Value < containerSize.Y)
+			if (VerticalAlignment == VerticalAlignment.Stretch && height != null && height.Value < containerSize.Y)
 			{
-				containerSize.Y = Height.Value;
+				containerSize.Y = height.Value;
 			}
 
 			// Align
@@ -1494,6 +1573,15 @@ namespace Myra.Graphics2D.UI
 		{
 			Width = style.Width;
 			Height = style.Height;
+			if (style.WidthDimension.HasValue)
+			{
+				WidthDimension = style.WidthDimension.Value;
+			}
+
+			if (style.HeightDimension.HasValue)
+			{
+				HeightDimension = style.HeightDimension.Value;
+			}
 			MinWidth = style.MinWidth;
 			MinHeight = style.MinHeight;
 			MaxWidth = style.MaxWidth;
@@ -1909,10 +1997,26 @@ namespace Myra.Graphics2D.UI
 			Top = w.Top;
 			MinWidth = w.MinWidth;
 			MaxWidth = w.MaxWidth;
-			Width = w.Width;
+			if (w.WidthDimension != Dimension.Auto)
+			{
+				WidthDimension = w.WidthDimension;
+			}
+			else
+			{
+				Width = w.Width;
+			}
+
 			MinHeight = w.MinHeight;
 			MaxHeight = w.MaxHeight;
-			Height = w.Height;
+			if (w.HeightDimension != Dimension.Auto)
+			{
+				HeightDimension = w.HeightDimension;
+			}
+			else
+			{
+				Height = w.Height;
+			}
+
 			Margin = w.Margin;
 			BorderThickness = w.BorderThickness;
 			Padding = w.Padding;

--- a/src/Myra/MML/TypeSerializers.cs
+++ b/src/Myra/MML/TypeSerializers.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using Myra.Graphics2D;
+using Myra.Graphics2D.UI;
 using Myra.Utility;
 using FontStashSharp.RichText;
 using System;
@@ -122,5 +123,12 @@ namespace Myra.MML
 		public override Rectangle DeserializeT(string str) => str.ParseRectangle();
 
 		public override string SerializeT(Rectangle obj) => obj.RectangleToString();
+	}
+
+	internal sealed class DimensionSerializer : TypeSerializer<Dimension>
+	{
+		public override Dimension DeserializeT(string str) => Dimension.Parse(str);
+
+		public override string SerializeT(Dimension obj) => obj.ToString();
 	}
 }

--- a/src/Myra/Utility/Serialization.cs
+++ b/src/Myra/Utility/Serialization.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Reflection;
 using Myra.Graphics2D;
+using Myra.Graphics2D.UI;
 using System;
 using System.Collections.Generic;
 using Myra.MML;
@@ -25,7 +26,8 @@ namespace Myra.Utility
 			{typeof(Vector2), new Vector2Serializer()},
 			{typeof(Thickness), new ThicknessSerializer()},
 			{typeof(Color), new ColorSerializer()},
-			{typeof(Rectangle), new RectangleSerializer()}
+			{typeof(Rectangle), new RectangleSerializer()},
+			{typeof(Dimension), new DimensionSerializer()}
 		};
 
 		public static bool HasDefaultValue(this PropertyInfo property, object value)

--- a/src/MyraPad/UI/MainForm.PropertyGrid.cs
+++ b/src/MyraPad/UI/MainForm.PropertyGrid.cs
@@ -103,6 +103,8 @@ partial class MainForm
 
 	private Widget CreateImageEditor(Record record, object obj)
 	{
+		const int previewHeight = 16;
+
 		var panel = new HorizontalStackPanel
 		{
 			Spacing = 8
@@ -113,7 +115,7 @@ partial class MainForm
 		{
 			HorizontalAlignment = HorizontalAlignment.Stretch,
 			VerticalAlignment = VerticalAlignment.Center,
-			Height = 16
+			Height = previewHeight
 		};
 
 		StackPanel.SetProportionType(image, ProportionType.Fill);
@@ -131,7 +133,7 @@ partial class MainForm
 				image.HorizontalAlignment = HorizontalAlignment.Center;
 
 				var aspectRatio = (float)asImage.Size.X / asImage.Size.Y;
-				image.Width = (int)(aspectRatio * image.Height);
+				image.Width = (int)(aspectRatio * previewHeight);
 			}
 		}
 		else


### PR DESCRIPTION
Currently, the width/height are limited to pixels. While this is good, often time when writing UI code (similar to MML) it is helpful to use percentages of the parent container.

In this I have made it so the dimension type of height/width is explicitly stated and controlled.

The types now available are:
- `"auto"`: explicit the old null/default value of wrapping.
- `"fill"`
-`"ZZ%"` percentage of parent space
- `"ZZpx"`

If none is given, it will default to using pixels. This means it works on existing layouts. 

Types are case insensitive.